### PR TITLE
feat(staking): Chainlink USDC/USD oracle for exposure capacity

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -28,6 +28,7 @@ contract Deploy is Script {
             usdc,
             vm.envOr("MIN_STAKE", uint256(10_000e6)),
             vm.envOr("COOLDOWN", uint256(48 hours)),
+            vm.envOr("STALE_PRICE_THRESHOLD", uint256(24 hours)),
             deployer
         );
         console.log("Staking:", address(staking));

--- a/contracts/src/GauloiStaking.sol
+++ b/contracts/src/GauloiStaking.sol
@@ -6,6 +6,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IGauloiStaking} from "./interfaces/IGauloiStaking.sol";
+import {AggregatorV3Interface} from "./interfaces/AggregatorV3Interface.sol";
 import {DataTypes} from "./types/DataTypes.sol";
 
 contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
@@ -14,6 +15,11 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
     IERC20 public immutable stakeTokenContract;
     uint256 public minStakeAmount;
     uint256 public cooldownDuration;
+
+    // Chainlink USDC/USD price feed for oracle-adjusted exposure checks
+    AggregatorV3Interface public priceFeed;
+    uint8 public priceFeedDecimals;
+    uint256 public immutable stalePriceThreshold;
 
     // Authorized callers for permissioned functions
     address public escrow;
@@ -43,12 +49,15 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
         address _stakeToken,
         uint256 _minStake,
         uint256 _cooldownPeriod,
+        uint256 _stalePriceThreshold,
         address _owner
     ) Ownable(_owner) {
         require(_stakeToken != address(0), "GauloiStaking: zero address");
+        require(_stalePriceThreshold > 0, "GauloiStaking: zero threshold");
         stakeTokenContract = IERC20(_stakeToken);
         minStakeAmount = _minStake;
         cooldownDuration = _cooldownPeriod;
+        stalePriceThreshold = _stalePriceThreshold;
     }
 
     // --- Admin ---
@@ -69,6 +78,16 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
 
     function setCooldownPeriod(uint256 _cooldownPeriod) external onlyOwner {
         cooldownDuration = _cooldownPeriod;
+    }
+
+    function setPriceFeed(address _priceFeed) external onlyOwner {
+        if (_priceFeed == address(0)) {
+            priceFeed = AggregatorV3Interface(address(0));
+            priceFeedDecimals = 0;
+        } else {
+            priceFeed = AggregatorV3Interface(_priceFeed);
+            priceFeedDecimals = AggregatorV3Interface(_priceFeed).decimals();
+        }
     }
 
     // --- Maker staking ---
@@ -140,7 +159,8 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
         require(info.isActive, "GauloiStaking: maker not active");
 
         uint256 newExposure = info.activeExposure + amount;
-        require(newExposure <= info.stakedAmount, "GauloiStaking: exposure exceeds stake");
+        uint256 effectiveCapacity = _stakeValueInUsd(info.stakedAmount);
+        require(newExposure <= effectiveCapacity, "GauloiStaking: exposure exceeds stake");
 
         info.activeExposure = newExposure;
     }
@@ -185,7 +205,9 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
     function availableCapacity(address maker) external view returns (uint256) {
         DataTypes.MakerInfo storage info = _makers[maker];
         if (!info.isActive) return 0;
-        return info.stakedAmount - info.activeExposure;
+        uint256 effectiveCapacity = _stakeValueInUsd(info.stakedAmount);
+        if (effectiveCapacity <= info.activeExposure) return 0;
+        return effectiveCapacity - info.activeExposure;
     }
 
     function isActiveMaker(address maker) external view returns (bool) {
@@ -202,5 +224,27 @@ contract GauloiStaking is IGauloiStaking, Ownable, ReentrancyGuard {
 
     function cooldownPeriod() external view returns (uint256) {
         return cooldownDuration;
+    }
+
+    // --- Internal ---
+
+    /// @dev Returns the USD value of a USDC stake amount using the oracle.
+    ///      If no oracle is set, assumes 1:1 (i.e. returns the raw amount).
+    ///      Chainlink USDC/USD feeds use 8 decimals, USDC uses 6.
+    ///      Result is in 6-decimal "USD units" so it can be compared directly to fill amounts.
+    ///      Capped at stakedAmount so oracle can only reduce capacity, never inflate above 1:1.
+    function _stakeValueInUsd(uint256 stakedAmount) internal view returns (uint256) {
+        if (address(priceFeed) == address(0)) {
+            return stakedAmount;
+        }
+
+        (, int256 price,, uint256 updatedAt,) = priceFeed.latestRoundData();
+        require(price > 0, "GauloiStaking: invalid oracle price");
+        require(block.timestamp - updatedAt <= stalePriceThreshold, "GauloiStaking: stale oracle price");
+
+        // stakedAmount (6 decimals) * price (feedDecimals) / 10^feedDecimals = USD value (6 decimals)
+        uint256 oracleValue = (stakedAmount * uint256(price)) / (10 ** priceFeedDecimals);
+        // Cap: oracle can only reduce capacity, never inflate above 1:1
+        return oracleValue < stakedAmount ? oracleValue : stakedAmount;
     }
 }

--- a/contracts/src/interfaces/AggregatorV3Interface.sol
+++ b/contracts/src/interfaces/AggregatorV3Interface.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @dev Minimal Chainlink AggregatorV3Interface for price feed reads.
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/contracts/src/interfaces/IGauloiStaking.sol
+++ b/contracts/src/interfaces/IGauloiStaking.sol
@@ -37,4 +37,7 @@ interface IGauloiStaking {
     function stakeToken() external view returns (address);
     function minStake() external view returns (uint256);
     function cooldownPeriod() external view returns (uint256);
+
+    // --- Oracle ---
+    function setPriceFeed(address _priceFeed) external;
 }

--- a/contracts/test/fork/ForkSettlement.t.sol
+++ b/contracts/test/fork/ForkSettlement.t.sol
@@ -69,7 +69,7 @@ contract ForkSettlementTest is Test {
         makerC = vm.addr(makerCKey);
 
         // Deploy protocol using USDC as stake token
-        staking = new GauloiStaking(USDC, MIN_STAKE, COOLDOWN, owner);
+        staking = new GauloiStaking(USDC, MIN_STAKE, COOLDOWN, 1 hours, owner);
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), USDC,

--- a/contracts/test/gas/GasBenchmark.t.sol
+++ b/contracts/test/gas/GasBenchmark.t.sol
@@ -53,7 +53,7 @@ contract GasBenchmark is Test {
         maker3 = vm.addr(maker3Key);
 
         usdc = new MockERC20("USD Coin", "USDC", 6);
-        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, owner);
+        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), address(usdc),

--- a/contracts/test/helpers/BaseTest.sol
+++ b/contracts/test/helpers/BaseTest.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "./MockERC20.sol";
+import {MockPriceFeed} from "./MockPriceFeed.sol";
 import {GauloiStaking} from "../../src/GauloiStaking.sol";
 import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
@@ -12,6 +13,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 
 abstract contract BaseTest is Test {
     MockERC20 public usdc;
+    MockPriceFeed public priceFeed;
     GauloiStaking public staking;
     GauloiEscrow public escrow;
 
@@ -40,12 +42,18 @@ abstract contract BaseTest is Test {
         taker = vm.addr(takerKey);
 
         usdc = new MockERC20("USD Coin", "USDC", 6);
+        priceFeed = new MockPriceFeed(1e8, 8); // USDC at $1.00, 8 decimals
         staking = new GauloiStaking(
             address(usdc),
             MIN_STAKE,
             COOLDOWN,
+            1 hours,
             owner
         );
+
+        // Set oracle on staking
+        vm.prank(owner);
+        staking.setPriceFeed(address(priceFeed));
 
         // Fund makers and taker
         usdc.mint(maker1, 1_000_000e6);

--- a/contracts/test/helpers/MockPriceFeed.sol
+++ b/contracts/test/helpers/MockPriceFeed.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {AggregatorV3Interface} from "../../src/interfaces/AggregatorV3Interface.sol";
+
+contract MockPriceFeed is AggregatorV3Interface {
+    int256 private _price;
+    uint8 private _decimals;
+    uint256 private _updatedAt;
+
+    constructor(int256 initialPrice, uint8 feedDecimals) {
+        _price = initialPrice;
+        _decimals = feedDecimals;
+        _updatedAt = block.timestamp;
+    }
+
+    function setPrice(int256 newPrice) external {
+        _price = newPrice;
+        _updatedAt = block.timestamp;
+    }
+
+    function setUpdatedAt(uint256 ts) external {
+        _updatedAt = ts;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        return (1, _price, block.timestamp, _updatedAt, 1);
+    }
+}

--- a/contracts/test/integration/SettlementLoop.t.sol
+++ b/contracts/test/integration/SettlementLoop.t.sol
@@ -58,7 +58,7 @@ contract SettlementLoopTest is Test {
         usdt = new MockERC20("Tether USD", "USDT", 6);
 
         // Deploy protocol
-        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, owner);
+        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), address(usdc),

--- a/contracts/test/unit/GauloiDisputes.t.sol
+++ b/contracts/test/unit/GauloiDisputes.t.sol
@@ -34,7 +34,7 @@ contract GauloiDisputesTest is BaseTest {
         taker = vm.addr(takerKey);
 
         usdc = new MockERC20Harness("USD Coin", "USDC", 6);
-        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, owner);
+        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
 
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
 

--- a/contracts/test/unit/GauloiStaking.t.sol
+++ b/contracts/test/unit/GauloiStaking.t.sol
@@ -5,6 +5,7 @@ import {BaseTest} from "../helpers/BaseTest.sol";
 import {GauloiStaking} from "../../src/GauloiStaking.sol";
 import {IGauloiStaking} from "../../src/interfaces/IGauloiStaking.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
+import {MockPriceFeed} from "../helpers/MockPriceFeed.sol";
 
 contract GauloiStakingTest is BaseTest {
     address public mockEscrow = makeAddr("escrow");
@@ -331,5 +332,129 @@ contract GauloiStakingTest is BaseTest {
         vm.prank(mockEscrow);
         vm.expectRevert("GauloiStaking: exposure exceeds stake");
         staking.increaseExposure(maker1, exposure);
+    }
+
+    // --- Oracle-adjusted exposure ---
+
+    function test_increaseExposure_oracleReducesCapacity() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        // USDC depegs to $0.50
+        priceFeed.setPrice(0.5e8);
+
+        // Stake is worth $25,000 — exposure of 30,000 should fail
+        vm.prank(mockEscrow);
+        vm.expectRevert("GauloiStaking: exposure exceeds stake");
+        staking.increaseExposure(maker1, 30_000e6);
+
+        // But 25,000 should succeed
+        vm.prank(mockEscrow);
+        staking.increaseExposure(maker1, 25_000e6);
+
+        assertEq(staking.getMakerInfo(maker1).activeExposure, 25_000e6);
+    }
+
+    function test_availableCapacity_oracleAdjusted() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        // At $1.00, capacity = 50,000
+        assertEq(staking.availableCapacity(maker1), 50_000e6);
+
+        // USDC depegs to $0.80
+        priceFeed.setPrice(0.8e8);
+        assertEq(staking.availableCapacity(maker1), 40_000e6);
+
+        // Add some exposure
+        vm.prank(mockEscrow);
+        staking.increaseExposure(maker1, 20_000e6);
+        assertEq(staking.availableCapacity(maker1), 20_000e6);
+    }
+
+    function test_increaseExposure_staleOracle_reverts() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        // Warp to a reasonable timestamp, then set oracle updatedAt to 2 hours ago
+        vm.warp(10 hours);
+        priceFeed.setUpdatedAt(block.timestamp - 2 hours);
+
+        vm.prank(mockEscrow);
+        vm.expectRevert("GauloiStaking: stale oracle price");
+        staking.increaseExposure(maker1, 10_000e6);
+    }
+
+    function test_increaseExposure_noPriceFeed_fallsBackTo1to1() public {
+        // Deploy fresh staking without oracle
+        GauloiStaking noOracleStaking = new GauloiStaking(
+            address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner
+        );
+        vm.startPrank(owner);
+        noOracleStaking.setEscrow(mockEscrow);
+        vm.stopPrank();
+
+        vm.startPrank(maker1);
+        usdc.approve(address(noOracleStaking), 50_000e6);
+        noOracleStaking.stake(50_000e6);
+        vm.stopPrank();
+
+        // Without oracle, 50k stake = 50k capacity (raw 1:1)
+        assertEq(noOracleStaking.availableCapacity(maker1), 50_000e6);
+
+        vm.prank(mockEscrow);
+        noOracleStaking.increaseExposure(maker1, 50_000e6);
+        assertEq(noOracleStaking.availableCapacity(maker1), 0);
+    }
+
+    function test_increaseExposure_negativeOraclePrice_reverts() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        priceFeed.setPrice(-1);
+
+        vm.prank(mockEscrow);
+        vm.expectRevert("GauloiStaking: invalid oracle price");
+        staking.increaseExposure(maker1, 10_000e6);
+    }
+
+    function test_setPriceFeed_onlyOwner() public {
+        vm.prank(maker1);
+        vm.expectRevert();
+        staking.setPriceFeed(makeAddr("feed"));
+    }
+
+    function test_setPriceFeed_zeroAddress_disablesOracle() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        // Disable oracle
+        vm.prank(owner);
+        staking.setPriceFeed(address(0));
+
+        // Should fall back to 1:1
+        assertEq(staking.availableCapacity(maker1), 50_000e6);
+    }
+
+    function test_availableCapacity_cappedAbovePeg() public {
+        _stakeMaker(maker1, 50_000e6);
+
+        // USDC at $1.05 — capacity should still be 50,000 (capped at 1:1)
+        priceFeed.setPrice(1.05e8);
+        assertEq(staking.availableCapacity(maker1), 50_000e6);
+
+        // USDC at $2.00 — still capped
+        priceFeed.setPrice(2e8);
+        assertEq(staking.availableCapacity(maker1), 50_000e6);
+    }
+
+    function testFuzz_oracleAdjustedCapacity(uint256 stakeAmt, uint256 priceCents) public {
+        stakeAmt = bound(stakeAmt, MIN_STAKE, 1_000_000e6);
+        priceCents = bound(priceCents, 1, 200); // $0.01 to $2.00
+
+        _stakeMaker(maker1, stakeAmt);
+
+        int256 oraclePrice = int256(priceCents * 1e6); // 8-decimal price from cents
+        priceFeed.setPrice(oraclePrice);
+
+        uint256 rawCapacity = (stakeAmt * priceCents * 1e6) / 1e8;
+        // Capped at stakedAmount — oracle can only reduce, never inflate
+        uint256 expectedCapacity = rawCapacity < stakeAmt ? rawCapacity : stakeAmt;
+        assertEq(staking.availableCapacity(maker1), expectedCapacity);
     }
 }


### PR DESCRIPTION
## Summary

- Integrates a Chainlink USDC/USD price feed into `GauloiStaking` so maker exposure capacity reflects the real USD value of staked USDC during a depeg
- Oracle can only **reduce** capacity below 1:1, never inflate above it (prevents USDC > $1 from over-collateralizing)
- `setPriceFeed(address(0))` acts as an emergency kill switch, falling back to raw 1:1
- `stalePriceThreshold` is **immutable** (set at deploy time) — matches Chainlink's heartbeat which isn't queryable on-chain
- `priceFeed.decimals()` is cached in `priceFeedDecimals` on `setPriceFeed()` to save gas per exposure check
- Adds `AggregatorV3Interface` and `MockPriceFeed` for testing
- 102 tests pass across all suites (staking, escrow, disputes, integration, gas benchmarks)

## Related

- Follow-up: Emit events on `setPriceFeed` changes — #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)