### PR TITLE
fix(maker): verify fill transfer logs, not just tx existence

### DIFF
--- a/packages/maker/src/bot.ts
+++ b/packages/maker/src/bot.ts
@@ -57,6 +57,8 @@ export class MakerBot {
   // Local pending exposure tracking — prevents over-quoting between on-chain confirmations
   private pendingExposure: Map<string, { amount: bigint; expiresAt: number }> =
     new Map();
+  // Cache orders by intentId for fill verification and dispute submission
+  private orderCache = new Map<string, Order>();
 
   constructor(config: BotConfig) {
     this.config = config;
@@ -102,10 +104,11 @@ export class MakerBot {
 
     // Start watching fills for dispute monitoring
     this.chainWatcher.watchFills(async (event) => {
-      const valid = await this.disputeWatcher.verifyFill(event);
+      const order = this.orderCache.get(event.intentId);
+      const valid = await this.disputeWatcher.verifyFill(event, order);
       if (!valid) {
         console.log(`Invalid fill detected: ${event.intentId}`);
-        await this.disputeWatcher.dispute(event.intentId);
+        await this.disputeWatcher.dispute(event.intentId, order);
       }
     });
 
@@ -349,6 +352,9 @@ export class MakerBot {
         nonce: BigInt(nonce),
       };
 
+      // Cache order for fill verification and dispute submission
+      this.orderCache.set(intentId, order);
+
       // 1. Execute order on source chain (replaces commitToIntent)
       console.log("Executing order on source chain...");
       await this.filler.executeOrder(order, takerSignature as `0x${string}`);
@@ -383,6 +389,7 @@ export class MakerBot {
     } catch (err) {
       // Release local reservation on failure
       this.pendingExposure.delete(intentId);
+      this.orderCache.delete(intentId);
       this.capacityLastFetched = 0;
       console.error(`Fill failed for intent ${intentId}:`, err);
     }

--- a/packages/maker/src/dispute/watcher.test.ts
+++ b/packages/maker/src/dispute/watcher.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi } from "vitest";
+import { encodeEventTopics, encodeAbiParameters, parseAbiItem } from "viem";
+import { DisputeWatcher } from "./watcher.js";
+import type { FillSubmittedEvent } from "../chain/watcher.js";
+import type { Order } from "@gauloi/common";
+
+// --- helpers ---
+
+const MAKER = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as `0x${string}`;
+const OTHER_MAKER = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`;
+const DISPUTES = "0xcccccccccccccccccccccccccccccccccccccccc" as `0x${string}`;
+const OUTPUT_TOKEN = "0x3333333333333333333333333333333333333333" as `0x${string}`;
+const DEST_ADDR = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+
+const TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+);
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    taker: "0x1111111111111111111111111111111111111111",
+    inputToken: "0x2222222222222222222222222222222222222222",
+    inputAmount: 1_000_000n,
+    outputToken: OUTPUT_TOKEN,
+    minOutputAmount: 990_000n,
+    destinationChainId: 421614n,
+    destinationAddress: DEST_ADDR,
+    expiry: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    nonce: 1n,
+    ...overrides,
+  };
+}
+
+function makeFillEvent(overrides: Partial<FillSubmittedEvent> = {}): FillSubmittedEvent {
+  return {
+    intentId: "0xINTENT1" as `0x${string}`,
+    maker: OTHER_MAKER,
+    fillTxHash: "0xFILL_TX" as `0x${string}`,
+    disputeWindowEnd: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    ...overrides,
+  };
+}
+
+/** Build a mock ERC20 Transfer log with proper ABI encoding */
+function makeTransferLog(
+  tokenAddress: `0x${string}`,
+  from: `0x${string}`,
+  to: `0x${string}`,
+  value: bigint,
+) {
+  const topics = encodeEventTopics({
+    abi: [TRANSFER_EVENT],
+    eventName: "Transfer",
+    args: { from, to },
+  });
+
+  const data = encodeAbiParameters(
+    [{ type: "uint256" }],
+    [value],
+  );
+
+  return {
+    address: tokenAddress,
+    topics,
+    data,
+    blockNumber: 100n,
+    transactionHash: "0xFILL_TX" as `0x${string}`,
+    logIndex: 0,
+    blockHash: "0x" as `0x${string}`,
+    transactionIndex: 0,
+    removed: false,
+  };
+}
+
+// --- tests ---
+
+describe("DisputeWatcher.verifyFill", () => {
+  it("returns true for own fills (skips verification)", async () => {
+    const destPublicClient = { getTransactionReceipt: vi.fn() } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(
+      makeFillEvent({ maker: MAKER }),
+      makeOrder(),
+    );
+
+    expect(result).toBe(true);
+    expect(destPublicClient.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it("returns false when no order data is provided", async () => {
+    const destPublicClient = { getTransactionReceipt: vi.fn() } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when receipt contains valid Transfer log", async () => {
+    const transferLog = makeTransferLog(
+      OUTPUT_TOKEN,
+      OTHER_MAKER,
+      DEST_ADDR,
+      990_000n,
+    );
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when transfer amount exceeds minOutputAmount", async () => {
+    const transferLog = makeTransferLog(
+      OUTPUT_TOKEN,
+      OTHER_MAKER,
+      DEST_ADDR,
+      2_000_000n, // More than min
+    );
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when transfer is to wrong recipient", async () => {
+    const wrongRecipient = "0xdddddddddddddddddddddddddddddddddddddddd" as `0x${string}`;
+    const transferLog = makeTransferLog(
+      OUTPUT_TOKEN,
+      OTHER_MAKER,
+      wrongRecipient,
+      990_000n,
+    );
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when transfer amount is below minOutputAmount", async () => {
+    const transferLog = makeTransferLog(
+      OUTPUT_TOKEN,
+      OTHER_MAKER,
+      DEST_ADDR,
+      500_000n, // Below min
+    );
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when transfer is on wrong token contract", async () => {
+    const wrongToken = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as `0x${string}`;
+    const transferLog = makeTransferLog(
+      wrongToken,
+      OTHER_MAKER,
+      DEST_ADDR,
+      990_000n,
+    );
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when transaction reverted", async () => {
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "reverted",
+        logs: [],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when receipt has no logs", async () => {
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when getTransactionReceipt throws", async () => {
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockRejectedValue(new Error("not found")),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(false);
+  });
+
+  it("handles case-insensitive address comparison", async () => {
+    const transferLog = makeTransferLog(
+      OUTPUT_TOKEN,
+      OTHER_MAKER,
+      DEST_ADDR,
+      990_000n,
+    );
+    // Override address to uppercase to test case-insensitivity
+    transferLog.address = OUTPUT_TOKEN.toUpperCase() as `0x${string}`;
+
+    const destPublicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [transferLog],
+      }),
+    } as any;
+    const sourceWalletClient = {} as any;
+
+    const watcher = new DisputeWatcher(destPublicClient, sourceWalletClient, DISPUTES, MAKER);
+
+    const result = await watcher.verifyFill(makeFillEvent(), makeOrder());
+
+    expect(result).toBe(true);
+  });
+});

--- a/packages/maker/src/dispute/watcher.ts
+++ b/packages/maker/src/dispute/watcher.ts
@@ -3,15 +3,20 @@ import {
   type WalletClient,
   type Transport,
   type Chain,
+  parseAbiItem,
+  decodeEventLog,
 } from "viem";
 import { type PrivateKeyAccount } from "viem/accounts";
 import { GauloiDisputesAbi, type Order } from "@gauloi/common";
 import type { FillSubmittedEvent } from "../chain/watcher.js";
 
+const ERC20_TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+);
+
 /**
  * Monitors fills and disputes invalid ones.
- * For v0.1, verification is simulated — in production this
- * would check the destination chain RPC for the claimed tx.
+ * Verifies destination chain ERC20 Transfer logs match intent parameters.
  */
 export class DisputeWatcher {
   constructor(
@@ -22,24 +27,63 @@ export class DisputeWatcher {
   ) {}
 
   /**
-   * Verify a fill by checking the destination chain for the claimed transaction.
+   * Verify a fill by checking the destination chain tx receipt for a matching
+   * ERC20 Transfer log (correct token, recipient, and amount).
    * Returns true if the fill is valid.
    */
-  async verifyFill(event: FillSubmittedEvent): Promise<boolean> {
+  async verifyFill(event: FillSubmittedEvent, order?: Order): Promise<boolean> {
     // Don't verify our own fills
     if (event.maker.toLowerCase() === this.makerAddress.toLowerCase()) {
       return true;
     }
 
+    if (!order) {
+      console.warn(`No order data for intent ${event.intentId} — cannot verify fill`);
+      return false;
+    }
+
     try {
-      // Check if the transaction exists on the destination chain
-      const tx = await this.destPublicClient.getTransaction({
+      const receipt = await this.destPublicClient.getTransactionReceipt({
         hash: event.fillTxHash,
       });
 
-      // Transaction exists — basic validity check
-      // In production: verify recipient, amount, token match the intent parameters
-      return tx !== null;
+      if (receipt.status === "reverted") {
+        return false;
+      }
+
+      // Look for an ERC20 Transfer log on the output token contract
+      // that sends at least minOutputAmount to the destination address
+      for (const log of receipt.logs) {
+        // Skip logs from other contracts
+        if (log.address.toLowerCase() !== order.outputToken.toLowerCase()) {
+          continue;
+        }
+
+        try {
+          const decoded = decodeEventLog({
+            abi: [ERC20_TRANSFER_EVENT],
+            data: log.data,
+            topics: log.topics,
+          });
+
+          if (decoded.eventName !== "Transfer") continue;
+
+          const { to, value } = decoded.args;
+
+          const recipientMatch =
+            to.toLowerCase() === order.destinationAddress.toLowerCase();
+          const amountSufficient = value >= order.minOutputAmount;
+
+          if (recipientMatch && amountSufficient) {
+            return true;
+          }
+        } catch {
+          // Not a Transfer event or wrong ABI — skip
+        }
+      }
+
+      // No matching Transfer log found
+      return false;
     } catch {
       // Transaction not found — potentially fraudulent
       return false;


### PR DESCRIPTION
## Summary
- `DisputeWatcher.verifyFill()` only checked if the destination chain tx existed via `getTransaction()`, which allowed a malicious maker to submit any valid tx hash as fill evidence
- Now fetches the transaction receipt and parses ERC20 Transfer logs to verify:
  - Transfer is on the correct output token contract
  - Recipient matches `destinationAddress`
  - Amount is at least `minOutputAmount`
- Added `orderCache` to `MakerBot` to provide order data to both `verifyFill()` and `dispute()`

## Test plan
- [x] 11 unit tests for `DisputeWatcher.verifyFill()`:
  - Own fills skip verification
  - Missing order returns false
  - Valid Transfer log → true
  - Transfer exceeding minOutputAmount → true
  - Wrong recipient → false
  - Insufficient amount → false
  - Wrong token contract → false
  - Reverted transaction → false
  - No logs → false
  - RPC error → false
  - Case-insensitive address matching
- [x] `pnpm --filter @gauloi/maker test` passes
- [x] `pnpm --filter @gauloi/maker build` passes

Closes #14