### PR TITLE
chore: redeploy contracts with oracle pricing support

### DIFF
--- a/packages/common/src/abis/GauloiStaking.ts
+++ b/packages/common/src/abis/GauloiStaking.ts
@@ -18,6 +18,11 @@ export const GauloiStakingAbi = [
         "internalType": "uint256"
       },
       {
+        "name": "_stalePriceThreshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
         "name": "_owner",
         "type": "address",
         "internalType": "address"
@@ -245,6 +250,32 @@ export const GauloiStakingAbi = [
   },
   {
     "type": "function",
+    "name": "priceFeed",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AggregatorV3Interface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "priceFeedDecimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "renounceOwnership",
     "inputs": [],
     "outputs": [],
@@ -317,6 +348,19 @@ export const GauloiStakingAbi = [
   },
   {
     "type": "function",
+    "name": "setPriceFeed",
+    "inputs": [
+      {
+        "name": "_priceFeed",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "slash",
     "inputs": [
       {
@@ -374,6 +418,19 @@ export const GauloiStakingAbi = [
         "name": "",
         "type": "address",
         "internalType": "contract IERC20"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "stalePriceThreshold",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"

--- a/packages/common/src/constants/chains.ts
+++ b/packages/common/src/constants/chains.ts
@@ -31,9 +31,9 @@ export const SEPOLIA: ChainConfig = {
   rpcUrl: process.env.SEPOLIA_RPC_URL ?? "",
   settlementWindow: 2 * 60, // 2 minutes (testnet)
   commitmentTimeout: 2 * 60, // 2 minutes
-  escrowAddress: "0x61bc65601290bD7CBfF2461a1C2B81d0892064Dd",
-  stakingAddress: "0xc157d212a20361f8DBD4D6D890Ba19C62E1bf181",
-  disputesAddress: "0xf9fFa89F4B3d3b63c389D91B06D805534BcE9256",
+  escrowAddress: "0x4A01bc51DF2c58C9fCad0413B3417a47bADE0e52",
+  stakingAddress: "0x363531686E6a0B1A52189bE878038075B14cBCcB",
+  disputesAddress: "0x49CFF580Ad8A15B82a22f9376e65Dc9CebFEc94a",
 };
 
 export const ARBITRUM_SEPOLIA: ChainConfig = {
@@ -42,9 +42,9 @@ export const ARBITRUM_SEPOLIA: ChainConfig = {
   rpcUrl: process.env.ARBITRUM_SEPOLIA_RPC_URL ?? "",
   settlementWindow: 2 * 60, // 2 minutes (testnet)
   commitmentTimeout: 2 * 60, // 2 minutes
-  escrowAddress: "0x94AC29e9888314Bf9Addc60c7CB3FFa876e7565a",
-  stakingAddress: "0x34C49c7fe668cDdD13a8Af5677d3d71d57eFdddc",
-  disputesAddress: "0xe2D845c033F8BEF0d10c6c1B06BdE4882f3b0f8a",
+  escrowAddress: "0xf9fFa89F4B3d3b63c389D91B06D805534BcE9256",
+  stakingAddress: "0x61bc65601290bD7CBfF2461a1C2B81d0892064Dd",
+  disputesAddress: "0x9938386603295918D6A4167839297fCB46FaF3E1",
 };
 
 export const SUPPORTED_CHAINS: Record<number, ChainConfig> = {


### PR DESCRIPTION
## Summary
- Redeployed GauloiStaking, GauloiEscrow, and GauloiDisputes to both Eth Sepolia and Arb Sepolia
- New contracts include oracle pricing support (`setPriceFeed`, `stalePriceThreshold`) in GauloiStaking
- Updated chain config addresses in `packages/common/src/constants/chains.ts`
- Regenerated staking ABI to include new oracle functions
- All contract permissions wired (`setEscrow`, `setDisputes`, `addSupportedToken`)

## New addresses

| Chain | Contract | Address |
|---|---|---|
| Eth Sepolia | Staking | `0x363531686E6a0B1A52189bE878038075B14cBCcB` |
| Eth Sepolia | Escrow | `0x4A01bc51DF2c58C9fCad0413B3417a47bADE0e52` |
| Eth Sepolia | Disputes | `0x49CFF580Ad8A15B82a22f9376e65Dc9CebFEc94a` |
| Arb Sepolia | Staking | `0x61bc65601290bD7CBfF2461a1C2B81d0892064Dd` |
| Arb Sepolia | Escrow | `0xf9fFa89F4B3d3b63c389D91B06D805534BcE9256` |
| Arb Sepolia | Disputes | `0x9938386603295918D6A4167839297fCB46FaF3E1` |