### PR TITLE
fix(app): auto-prune stale intents from activity page

### DIFF
--- a/app/src/app/activity/page.tsx
+++ b/app/src/app/activity/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IntentStatus } from "@/components/IntentStatus";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 
 interface StoredIntent {
@@ -28,6 +28,14 @@ export default function ActivityPage() {
     return () => clearInterval(interval);
   }, []);
 
+  const handlePrune = useCallback((intentId: string) => {
+    setIntents((prev) => {
+      const filtered = prev.filter((i) => i.intentId !== intentId);
+      localStorage.setItem("gauloi_intents", JSON.stringify(filtered));
+      return filtered;
+    });
+  }, []);
+
   if (intents.length === 0) {
     return (
       <div className="text-center py-20">
@@ -49,7 +57,18 @@ export default function ActivityPage() {
     <div className="space-y-3">
       <div className="flex justify-between items-center mb-4">
         <h2 className="font-pixel text-sm text-pixel-cyan">ACTIVITY</h2>
-        <span className="font-pixel text-[8px] text-teal-600">{intents.length} TOTAL</span>
+        <div className="flex items-center gap-3">
+          <span className="font-pixel text-[8px] text-teal-600">{intents.length} TOTAL</span>
+          <button
+            onClick={() => {
+              localStorage.removeItem("gauloi_intents");
+              setIntents([]);
+            }}
+            className="font-pixel text-[8px] text-red-400 hover:text-red-300 transition-colors"
+          >
+            REFRESH
+          </button>
+        </div>
       </div>
       {intents.map((intent) => (
         <IntentStatus
@@ -59,6 +78,7 @@ export default function ActivityPage() {
           sourceChainId={intent.sourceChainId}
           destChainId={intent.destChainId}
           timestamp={intent.timestamp}
+          onPrune={handlePrune}
         />
       ))}
     </div>

--- a/app/src/components/IntentStatus.tsx
+++ b/app/src/components/IntentStatus.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useIntentStatus } from "@/hooks/useIntentStatus";
+import { useEffect } from "react";
 import { SUPPORTED_CHAINS, IntentState } from "@gauloi/common";
 import { CopyableAddress } from "./CopyableAddress";
 
@@ -10,6 +11,7 @@ interface IntentStatusProps {
   sourceChainId: number;
   destChainId: number;
   timestamp: number;
+  onPrune?: (intentId: string) => void;
 }
 
 const STATE_STYLES: Record<number, string> = {
@@ -20,15 +22,25 @@ const STATE_STYLES: Record<number, string> = {
   [IntentState.Expired]: "border-navy-600 text-teal-600",
 };
 
+// Intents older than 10 minutes with no on-chain commitment are dead
+const PRUNE_AGE_MS = 10 * 60 * 1000;
+
 export function IntentStatus({
   intentId,
   inputAmount,
   sourceChainId,
   destChainId,
   timestamp,
+  onPrune,
 }: IntentStatusProps) {
   const escrowAddress = SUPPORTED_CHAINS[sourceChainId]?.escrowAddress;
   const { state, label, isLoading } = useIntentStatus(intentId, escrowAddress, sourceChainId);
+
+  useEffect(() => {
+    if (!isLoading && state === null && Date.now() - timestamp > PRUNE_AGE_MS) {
+      onPrune?.(intentId);
+    }
+  }, [isLoading, state, timestamp, intentId, onPrune]);
 
   const sourceName = SUPPORTED_CHAINS[sourceChainId]?.name ?? `Chain ${sourceChainId}`;
   const destName = SUPPORTED_CHAINS[destChainId]?.name ?? `Chain ${destChainId}`;


### PR DESCRIPTION
## Summary
- Dead intents (no on-chain commitment after 10 minutes) are automatically pruned from the activity list via `onPrune` callback
- Adds a REFRESH button as a manual fallback to clear all history
- Fixes stale "Pending" intents lingering after relay/contract redeploys

## Test plan
- [x] Deploy relay, submit a swap, verify it appears in activity
- [x] Wait 10+ minutes without committing on-chain — intent should auto-disappear
- [x] Click REFRESH to verify manual clear works