### PR TITLE
feat(contracts): GauloiFillRegistry — canonical destination-side fills

### DIFF
--- a/contracts/src/GauloiFillRegistry.sol
+++ b/contracts/src/GauloiFillRegistry.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IGauloiFillRegistry} from "./interfaces/IGauloiFillRegistry.sol";
+
+/// @notice Destination-side fill registry. Makes fills canonical, unique, on-chain facts:
+///         one fill per intent, one intent per fill. Deployed on every chain Gauloi
+///         delivers to; makers route destination transfers through `fill()` instead of
+///         bare ERC-20 transfers, so a fill's existence and parameters can be checked
+///         (or storage-proven) against a single mapping slot.
+///
+///         Deliberately permissionless and admin-free: the registry records transfers,
+///         it does not judge them. Whether a fill satisfies an order (token, recipient,
+///         amount >= minOutputAmount) is checked by whoever resolves disputes on the
+///         source chain, using the commitment preimage as evidence. The preimage travels
+///         with the proof because `minOutputAmount` is an inequality — it cannot be
+///         checked inside an opaque hash.
+contract GauloiFillRegistry is IGauloiFillRegistry, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // intentId => keccak256(abi.encode(token, recipient, amount, filler, block.number))
+    mapping(bytes32 => bytes32) internal _fills;
+
+    function fill(
+        bytes32 intentId,
+        address token,
+        address recipient,
+        uint256 amount
+    ) external nonReentrant {
+        require(intentId != bytes32(0), "GauloiFillRegistry: zero intent id");
+        require(token != address(0), "GauloiFillRegistry: zero token");
+        require(recipient != address(0), "GauloiFillRegistry: zero recipient");
+        require(amount > 0, "GauloiFillRegistry: zero amount");
+        require(_fills[intentId] == bytes32(0), "GauloiFillRegistry: already filled");
+
+        // Effects before interaction (CEI pattern)
+        _fills[intentId] = computeFillCommitment(token, recipient, amount, msg.sender, block.number);
+
+        emit Filled(intentId, token, recipient, amount, msg.sender);
+
+        // Deliver to recipient — reject fee-on-transfer tokens, since the recorded
+        // amount would otherwise overstate what the recipient actually received
+        uint256 balBefore = IERC20(token).balanceOf(recipient);
+        IERC20(token).safeTransferFrom(msg.sender, recipient, amount);
+        require(
+            IERC20(token).balanceOf(recipient) - balBefore == amount,
+            "GauloiFillRegistry: fee-on-transfer token"
+        );
+    }
+
+    // --- View functions ---
+
+    function getFill(bytes32 intentId) external view returns (bytes32) {
+        return _fills[intentId];
+    }
+
+    function isFilled(bytes32 intentId) external view returns (bool) {
+        return _fills[intentId] != bytes32(0);
+    }
+
+    function computeFillCommitment(
+        address token,
+        address recipient,
+        uint256 amount,
+        address filler,
+        uint256 blockNumber
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(token, recipient, amount, filler, blockNumber));
+    }
+}

--- a/contracts/src/interfaces/IGauloiFillRegistry.sol
+++ b/contracts/src/interfaces/IGauloiFillRegistry.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IGauloiFillRegistry {
+    // Events
+    event Filled(
+        bytes32 indexed intentId,
+        address indexed token,
+        address indexed recipient,
+        uint256 amount,
+        address filler
+    );
+
+    // Deliver `amount` of `token` to `recipient` and record the fill against `intentId`.
+    // Exactly one fill per intent — repeat calls for the same intentId revert.
+    function fill(bytes32 intentId, address token, address recipient, uint256 amount) external;
+
+    // --- View functions ---
+
+    // Commitment hash for a recorded fill (bytes32(0) if unfilled)
+    function getFill(bytes32 intentId) external view returns (bytes32);
+
+    function isFilled(bytes32 intentId) external view returns (bool);
+
+    // Recompute a fill commitment from its preimage — used by verifiers
+    // checking a proven storage slot against claimed fill parameters
+    function computeFillCommitment(
+        address token,
+        address recipient,
+        uint256 amount,
+        address filler,
+        uint256 blockNumber
+    ) external pure returns (bytes32);
+}

--- a/contracts/test/unit/GauloiFillRegistry.t.sol
+++ b/contracts/test/unit/GauloiFillRegistry.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {GauloiFillRegistry} from "../../src/GauloiFillRegistry.sol";
+import {IGauloiFillRegistry} from "../../src/interfaces/IGauloiFillRegistry.sol";
+import {MockERC20} from "../helpers/MockERC20.sol";
+import {MockFeeOnTransferToken} from "../helpers/MockFeeOnTransferToken.sol";
+
+contract GauloiFillRegistryTest is Test {
+    GauloiFillRegistry public registry;
+    MockERC20 public usdc;
+    MockFeeOnTransferToken public feeToken;
+
+    address public maker = makeAddr("maker");
+    address public recipient = makeAddr("recipient");
+
+    bytes32 public constant INTENT_ID = keccak256("intent-1");
+    uint256 public constant FILL_AMOUNT = 1_000e6;
+
+    function setUp() public {
+        registry = new GauloiFillRegistry();
+        usdc = new MockERC20("USD Coin", "USDC", 6);
+        feeToken = new MockFeeOnTransferToken("Fee Token", "FEE", 6);
+
+        usdc.mint(maker, 1_000_000e6);
+        feeToken.mint(maker, 1_000_000e6);
+
+        vm.startPrank(maker);
+        usdc.approve(address(registry), type(uint256).max);
+        feeToken.approve(address(registry), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    // --- fill ---
+
+    function test_Fill_TransfersToRecipient() public {
+        uint256 makerBefore = usdc.balanceOf(maker);
+
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        assertEq(usdc.balanceOf(recipient), FILL_AMOUNT);
+        assertEq(usdc.balanceOf(maker), makerBefore - FILL_AMOUNT);
+        assertEq(usdc.balanceOf(address(registry)), 0); // registry never holds funds
+    }
+
+    function test_Fill_RecordsCommitment() public {
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        bytes32 expected = registry.computeFillCommitment(
+            address(usdc), recipient, FILL_AMOUNT, maker, block.number
+        );
+        assertEq(registry.getFill(INTENT_ID), expected);
+        assertTrue(registry.isFilled(INTENT_ID));
+    }
+
+    function test_Fill_EmitsEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit IGauloiFillRegistry.Filled(INTENT_ID, address(usdc), recipient, FILL_AMOUNT, maker);
+
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+    }
+
+    function test_Fill_RevertsOnDoubleFill() public {
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        // Same intent, same filler
+        vm.prank(maker);
+        vm.expectRevert("GauloiFillRegistry: already filled");
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        // Same intent, different filler and params — still one fill per intent
+        address other = makeAddr("other");
+        usdc.mint(other, FILL_AMOUNT);
+        vm.startPrank(other);
+        usdc.approve(address(registry), FILL_AMOUNT);
+        vm.expectRevert("GauloiFillRegistry: already filled");
+        registry.fill(INTENT_ID, address(usdc), other, FILL_AMOUNT);
+        vm.stopPrank();
+    }
+
+    function test_Fill_DistinctIntentsSameParams() public {
+        // Two orders with identical params (different nonce → different intentId)
+        // each need their own fill — one transfer cannot be claimed twice
+        vm.startPrank(maker);
+        registry.fill(keccak256("intent-a"), address(usdc), recipient, FILL_AMOUNT);
+        registry.fill(keccak256("intent-b"), address(usdc), recipient, FILL_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(usdc.balanceOf(recipient), 2 * FILL_AMOUNT);
+        assertTrue(registry.isFilled(keccak256("intent-a")));
+        assertTrue(registry.isFilled(keccak256("intent-b")));
+    }
+
+    function test_Fill_RevertsOnFeeOnTransferToken() public {
+        vm.prank(maker);
+        vm.expectRevert("GauloiFillRegistry: fee-on-transfer token");
+        registry.fill(INTENT_ID, address(feeToken), recipient, FILL_AMOUNT);
+
+        assertFalse(registry.isFilled(INTENT_ID));
+    }
+
+    function test_Fill_RevertsWithoutApproval() public {
+        address stranger = makeAddr("stranger");
+        usdc.mint(stranger, FILL_AMOUNT);
+
+        vm.prank(stranger);
+        vm.expectRevert();
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+    }
+
+    function test_Fill_RevertsOnZeroInputs() public {
+        vm.startPrank(maker);
+
+        vm.expectRevert("GauloiFillRegistry: zero intent id");
+        registry.fill(bytes32(0), address(usdc), recipient, FILL_AMOUNT);
+
+        vm.expectRevert("GauloiFillRegistry: zero token");
+        registry.fill(INTENT_ID, address(0), recipient, FILL_AMOUNT);
+
+        vm.expectRevert("GauloiFillRegistry: zero recipient");
+        registry.fill(INTENT_ID, address(usdc), address(0), FILL_AMOUNT);
+
+        vm.expectRevert("GauloiFillRegistry: zero amount");
+        registry.fill(INTENT_ID, address(usdc), recipient, 0);
+
+        vm.stopPrank();
+    }
+
+    // --- views ---
+
+    function test_GetFill_UnfilledIsZero() public view {
+        assertEq(registry.getFill(INTENT_ID), bytes32(0));
+        assertFalse(registry.isFilled(INTENT_ID));
+    }
+
+    function test_ComputeFillCommitment_MatchesPreimage() public {
+        vm.roll(12_345);
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        // A verifier holding the preimage recomputes the slot value:
+        // wrong amount, filler, or block must not match
+        bytes32 stored = registry.getFill(INTENT_ID);
+        assertEq(stored, keccak256(abi.encode(address(usdc), recipient, FILL_AMOUNT, maker, uint256(12_345))));
+        assertTrue(stored != registry.computeFillCommitment(address(usdc), recipient, FILL_AMOUNT - 1, maker, 12_345));
+        assertTrue(stored != registry.computeFillCommitment(address(usdc), recipient, FILL_AMOUNT, recipient, 12_345));
+        assertTrue(stored != registry.computeFillCommitment(address(usdc), recipient, FILL_AMOUNT, maker, 12_344));
+    }
+
+    function testFuzz_Fill_CommitmentRoundTrip(bytes32 intentId, uint256 amount, uint64 blockNumber) public {
+        vm.assume(intentId != bytes32(0));
+        amount = bound(amount, 1, 1_000_000e6);
+        vm.roll(uint256(blockNumber) + 1);
+
+        vm.prank(maker);
+        registry.fill(intentId, address(usdc), recipient, amount);
+
+        assertEq(
+            registry.getFill(intentId),
+            registry.computeFillCommitment(address(usdc), recipient, amount, maker, block.number)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Implements the contract portion of #53 (Phase 1 of the v0.2 provable settlement redesign, umbrella #2).

- **`GauloiFillRegistry`** — destination-side registry: `fill(intentId, token, recipient, amount)` delivers to the recipient and records `keccak256(abi.encode(token, recipient, amount, msg.sender, block.number))` keyed by intentId. Repeat fills for the same intent revert — one fill per intent, one intent per fill, which kills double-claiming (one destination transfer presented as evidence for two identical orders).
- **Single-slot commitment by design** so resolution can verify — and later storage-prove (#56) — a fill against exactly one mapping slot. Verifiers receive the preimage as evidence and recompute the hash; the preimage travels with the proof because `amount >= minOutputAmount` is an inequality that can't be checked inside an opaque hash. `computeFillCommitment()` is exposed for verifiers.
- **Admin-free and permissionless** — no owner, no whitelist. The registry records transfers; whether a fill satisfies an order is judged at dispute resolution on the source chain. Fee-on-transfer tokens are rejected (recorded amount must never overstate delivery), matching escrow's existing pattern.

## Testing
- 11 new unit tests incl. fuzzed commitment round-trip: transfer + recording, event, double-fill rejection (same and different filler), distinct intents with identical params, fee-on-transfer rejection, zero-input reverts, preimage mismatch checks.
- `forge test`: 226 passing; the 1 failure (`ForkSettlement.setUp`) is pre-existing on master (needs a mainnet fork RPC not configured locally) and unrelated.

## Out of scope (remaining #53 checklist, after review)
Testnet deploys + addresses into `packages/common/chains.ts`, maker-bot Filler wired to the registry.

Umbrella: #2 · Spec: README (PR #59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)