### PR TITLE
feat(disputes): Disputes v2 — permissionless challenges, maker-must-defend default, resolver routing

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -68,6 +68,7 @@ contract Deploy is Script {
             vm.envOr("RESOLUTION_WINDOW", uint256(24 hours)),
             vm.envOr("BOND_BPS", uint256(200)),
             vm.envOr("MIN_BOND", uint256(250e6)),
+            vm.envOr("TREASURY", owner),
             owner
         );
     }

--- a/contracts/src/GauloiDisputes.sol
+++ b/contracts/src/GauloiDisputes.sol
@@ -7,47 +7,46 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IGauloiDisputes} from "./interfaces/IGauloiDisputes.sol";
 import {IGauloiStaking} from "./interfaces/IGauloiStaking.sol";
+import {IResolver} from "./interfaces/IResolver.sol";
 import {GauloiEscrow} from "./GauloiEscrow.sol";
 import {DataTypes} from "./types/DataTypes.sol";
-import {SignatureLib} from "./libraries/SignatureLib.sol";
 import {IntentLib} from "./libraries/IntentLib.sol";
+import {TransferLib} from "./libraries/TransferLib.sol";
 
+/// @notice Dispute layer, v2. Detection and judgment are separated:
+///
+///         - Detection is permissionless. Anyone — the taker, a rival maker, a
+///           third-party watcher — challenges a fill claim by posting a bond.
+///         - Judgment terminates in the corridor's resolver (IResolver): a storage
+///           proof where the destination chain is provable, a named council where
+///           it is not. There is no attestor vote.
+///         - A challenged fill with no verdict by the deadline resolves INVALID:
+///           the maker must defend, silence convicts. This is safe because fills
+///           are registry-recorded on the destination chain, so an honest maker
+///           always has an unambiguous defense.
 contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
+    using TransferLib for IERC20;
 
     IGauloiStaking public staking;
     GauloiEscrow public escrow;
     IERC20 public bondToken; // Same as stake token (USDC)
+    address public treasury;
 
-    uint256 public disputeResolutionDuration; // Time to resolve before default
+    uint256 public disputeResolutionDuration; // Time for the maker to defend before default-invalid
     uint256 public disputeBondBps; // Bond as basis points of fill amount
     uint256 public minDisputeBond; // Minimum bond in absolute terms
-
-    bytes32 public immutable domainSeparator;
-
-    mapping(bytes32 => DataTypes.Dispute) internal _disputes;
-    mapping(bytes32 => DataTypes.Order) internal _disputeOrders;
-
-    // --- Phase A state (appended after slot 7 to preserve layout) ---
 
     // Slash curve params
     uint256 public slashBaseMultiplier; // 2
     uint256 public slashCurveK;         // 650e6
     uint256 public slashMaxMultiplier;  // 15
 
-    // Quorum
-    uint256 public quorumBps; // 3000 (30%)
+    // Corridor resolvers: destination chain id => terminal arbiter
+    mapping(uint256 => IResolver) public resolvers;
 
-    // Attestor recording — split by vote direction
-    mapping(bytes32 => address[]) internal _validAttestors;
-    mapping(bytes32 => address[]) internal _invalidAttestors;
-    mapping(bytes32 => mapping(address => uint256)) internal _attestorStakeWeights;
-    mapping(bytes32 => uint256) internal _totalValidWeight;
-    mapping(bytes32 => uint256) internal _totalInvalidWeight;
-    mapping(bytes32 => mapping(address => bool)) internal _hasAttested;
-
-    // Quorum failure
-    mapping(bytes32 => uint256) public quorumFailCount;
+    mapping(bytes32 => DataTypes.Dispute) internal _disputes;
+    mapping(bytes32 => DataTypes.Order) internal _disputeOrders;
 
     constructor(
         address _staking,
@@ -56,28 +55,42 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         uint256 _resolutionWindow,
         uint256 _bondBps,
         uint256 _minBond,
+        address _treasury,
         address _owner
     ) Ownable(_owner) {
-        require(_staking != address(0) && _escrow != address(0) && _bondToken != address(0),
-            "GauloiDisputes: zero address");
+        require(
+            _staking != address(0) && _escrow != address(0) && _bondToken != address(0)
+                && _treasury != address(0),
+            "GauloiDisputes: zero address"
+        );
         staking = IGauloiStaking(_staking);
         escrow = GauloiEscrow(_escrow);
         bondToken = IERC20(_bondToken);
+        treasury = _treasury;
         disputeResolutionDuration = _resolutionWindow;
         disputeBondBps = _bondBps;
         minDisputeBond = _minBond;
-        domainSeparator = SignatureLib.buildDomainSeparator("GauloiDisputes", address(this));
 
         // Slash curve defaults
         slashBaseMultiplier = 2;
         slashCurveK = 650e6;
         slashMaxMultiplier = 15;
-
-        // Quorum default: 30%
-        quorumBps = 3000;
     }
 
     // --- Admin ---
+
+    function setResolver(uint256 destinationChainId, address resolver) external onlyOwner {
+        address oldResolver = address(resolvers[destinationChainId]);
+        resolvers[destinationChainId] = IResolver(resolver);
+        emit ResolverUpdated(destinationChainId, oldResolver, resolver);
+    }
+
+    function setTreasury(address _treasury) external onlyOwner {
+        require(_treasury != address(0), "GauloiDisputes: zero address");
+        address oldTreasury = treasury;
+        treasury = _treasury;
+        emit TreasuryUpdated(oldTreasury, _treasury);
+    }
 
     function setDisputeResolutionWindow(uint256 newWindow) external onlyOwner {
         require(newWindow >= 1 hours && newWindow <= 30 days, "GauloiDisputes: window out of range");
@@ -101,13 +114,7 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         emit SlashCurveUpdated(_base, _k, _max);
     }
 
-    function setQuorumParams(uint256 _quorumBps) external onlyOwner {
-        require(_quorumBps <= 10_000, "GauloiDisputes: invalid quorum");
-        uint256 oldValue = quorumBps;
-        quorumBps = _quorumBps;
-        emit QuorumUpdated(oldValue, _quorumBps);
-    }
-
+    /// @dev Sweep funds held by this contract (failed reward transfers, dust)
     function withdrawTreasury(address to, uint256 amount) external onlyOwner nonReentrant {
         require(to != address(0), "GauloiDisputes: zero address");
         bondToken.safeTransfer(to, amount);
@@ -115,16 +122,14 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
 
     // --- Dispute lifecycle ---
 
-    function dispute(DataTypes.Order calldata order) external nonReentrant {
-        require(staking.isActiveMaker(msg.sender), "GauloiDisputes: not active maker");
-
+    function challenge(DataTypes.Order calldata order) external nonReentrant {
         bytes32 intentId = IntentLib.computeIntentId(order);
-        require(_disputes[intentId].challenger == address(0), "GauloiDisputes: already disputed");
+        require(_disputes[intentId].challenger == address(0), "GauloiDisputes: already challenged");
 
         DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
         require(commitment.state == DataTypes.IntentState.Filled, "GauloiDisputes: not filled");
         require(block.timestamp < commitment.disputeWindowEnd, "GauloiDisputes: window closed");
-        require(msg.sender != commitment.maker, "GauloiDisputes: cannot dispute own fill");
+        require(msg.sender != commitment.maker, "GauloiDisputes: cannot challenge own fill");
 
         uint256 bondAmount = calculateDisputeBond(order.inputAmount);
 
@@ -149,83 +154,32 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         emit DisputeRaised(intentId, msg.sender, bondAmount);
     }
 
-    function resolveDispute(
-        bytes32 intentId,
-        bool fillValid,
-        bytes[] calldata signatures
-    ) external nonReentrant {
+    function resolve(bytes32 intentId, bytes calldata evidence) external nonReentrant {
         DataTypes.Dispute storage disp = _disputes[intentId];
         require(disp.challenger != address(0), "GauloiDisputes: no dispute");
         require(!disp.resolved, "GauloiDisputes: already resolved");
         require(block.timestamp <= disp.disputeDeadline, "GauloiDisputes: deadline passed");
 
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
         DataTypes.Order storage order = _disputeOrders[intentId];
+        IResolver resolver = resolvers[order.destinationChainId];
+        require(address(resolver) != address(0), "GauloiDisputes: no resolver for corridor");
 
-        // Record each attestor's vote and stake weight
-        for (uint256 i = 0; i < signatures.length; i++) {
-            address signer = SignatureLib.recoverAttestor(
-                domainSeparator,
-                intentId,
-                fillValid,
-                commitment.fillTxHash,
-                order.destinationChainId,
-                signatures[i]
-            );
+        IResolver.Verdict verdict = resolver.resolve(intentId, order, evidence);
+        require(verdict != IResolver.Verdict.Pending, "GauloiDisputes: no verdict");
 
-            // Must be an active staked maker
-            require(staking.isActiveMaker(signer), "GauloiDisputes: signer not active maker");
-            // Must not be the disputed maker or the challenger (conflict of interest)
-            require(signer != commitment.maker, "GauloiDisputes: maker cannot attest own fill");
-            require(signer != disp.challenger, "GauloiDisputes: challenger cannot attest");
-            // No duplicate attestations across calls
-            require(!_hasAttested[intentId][signer], "GauloiDisputes: already attested");
+        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
 
-            uint256 weight = staking.getStake(signer);
-            _hasAttested[intentId][signer] = true;
-            _attestorStakeWeights[intentId][signer] = weight;
-
-            if (fillValid) {
-                _validAttestors[intentId].push(signer);
-                _totalValidWeight[intentId] += weight;
-            } else {
-                _invalidAttestors[intentId].push(signer);
-                _totalInvalidWeight[intentId] += weight;
-            }
-
-            emit AttestorRecorded(intentId, signer, fillValid, weight);
-        }
-
-        // Check quorum + majority
-        uint256 eligible = _eligibleVotingStake(commitment.maker, disp.challenger);
-        uint256 totalParticipating = _totalValidWeight[intentId] + _totalInvalidWeight[intentId];
-
-        // Quorum: participating >= quorumBps% of eligible
-        if (eligible == 0 || totalParticipating * 10_000 < eligible * quorumBps) {
-            return; // Not enough participation yet, votes recorded for future calls
-        }
-
-        // Strict majority: winningStake * 2 > totalParticipating
-        uint256 validWeight = _totalValidWeight[intentId];
-        uint256 invalidWeight = _totalInvalidWeight[intentId];
-
-        bool validWins = validWeight * 2 > totalParticipating;
-        bool invalidWins = invalidWeight * 2 > totalParticipating;
-
-        if (!validWins && !invalidWins) {
-            return; // No majority yet, votes recorded for future calls
-        }
-
+        bool valid = verdict == IResolver.Verdict.Valid;
         disp.resolved = true;
-        disp.fillDeemedValid = validWins;
+        disp.fillDeemedValid = valid;
 
-        if (validWins) {
+        if (valid) {
             _resolveAsValid(intentId, commitment, disp);
         } else {
             _resolveAsInvalid(intentId, commitment, disp);
         }
 
-        emit DisputeResolved(intentId, validWins);
+        emit DisputeResolved(intentId, valid);
     }
 
     function finalizeExpiredDispute(bytes32 intentId) external nonReentrant {
@@ -236,54 +190,14 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
 
         DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
 
-        uint256 totalParticipating = _totalValidWeight[intentId] + _totalInvalidWeight[intentId];
+        // The maker failed to defend a challenged fill: resolves against the fill.
+        // Safe because registry-recorded fills give every honest maker a defense —
+        // this default punishes silent fraud, not honest fills.
+        disp.resolved = true;
+        disp.fillDeemedValid = false;
+        _resolveAsInvalid(intentId, commitment, disp);
 
-        if (totalParticipating == 0) {
-            // Case 1: Zero attestations — default fill-valid (griefing backstop)
-            disp.resolved = true;
-            disp.fillDeemedValid = true;
-            _resolveAsValid(intentId, commitment, disp);
-            emit DisputeResolved(intentId, true);
-            return;
-        }
-
-        // Check if quorum was met
-        uint256 eligible = _eligibleVotingStake(commitment.maker, disp.challenger);
-        bool quorumMet = eligible > 0 && totalParticipating * 10_000 >= eligible * quorumBps;
-
-        if (quorumMet) {
-            // Case 2: Quorum met — resolve by plurality (more weight wins)
-            bool validWins = _totalValidWeight[intentId] >= _totalInvalidWeight[intentId];
-
-            disp.resolved = true;
-            disp.fillDeemedValid = validWins;
-
-            if (validWins) {
-                _resolveAsValid(intentId, commitment, disp);
-            } else {
-                _resolveAsInvalid(intentId, commitment, disp);
-            }
-
-            emit DisputeResolved(intentId, validWins);
-        } else {
-            // Case 3: Quorum NOT met
-            quorumFailCount[intentId]++;
-
-            if (quorumFailCount[intentId] >= 2) {
-                // Second failure — pause escrow
-                escrow.pause();
-
-                // Default to fill-valid to resolve the dispute
-                disp.resolved = true;
-                disp.fillDeemedValid = true;
-                _resolveAsValid(intentId, commitment, disp);
-                emit DisputeResolved(intentId, true);
-            } else {
-                // First failure — extend deadline
-                disp.disputeDeadline = block.timestamp + disputeResolutionDuration;
-                emit QuorumExtended(intentId, disp.disputeDeadline, quorumFailCount[intentId]);
-            }
-        }
+        emit DisputeResolved(intentId, false);
     }
 
     // --- Internal resolution ---
@@ -295,22 +209,17 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
     ) internal {
         DataTypes.Order storage order = _disputeOrders[intentId];
 
-        // Fill was valid — disputer was wrong
-        // Bond pool: 50% to maker, 25% to correct attestors, 25% + dust to treasury
+        // Fill was valid — challenger was wrong.
+        // Bond: 50% to the wrongly-accused maker, 50% (+ dust) to treasury.
         uint256 makerReward = disp.bondAmount / 2;
-        uint256 attestorPool = disp.bondAmount / 4;
+        uint256 treasuryShare = disp.bondAmount - makerReward;
 
-        // Use try/catch to prevent a blacklisted maker from blocking resolution
-        try bondToken.transfer(commitment.maker, makerReward) returns (bool success) {
-            if (!success) {
-                emit MakerRewardFailed(intentId, commitment.maker, makerReward);
-            }
-        } catch {
+        if (!bondToken.tryTransfer(commitment.maker, makerReward)) {
             emit MakerRewardFailed(intentId, commitment.maker, makerReward);
         }
-
-        // Distribute attestor rewards (valid-side attestors)
-        _distributeAttestorRewards(intentId, true, attestorPool);
+        if (!bondToken.tryTransfer(treasury, treasuryShare)) {
+            emit TreasuryTransferFailed(intentId, treasuryShare);
+        }
 
         // Release escrow to maker
         escrow.resolveValid(intentId, order);
@@ -328,7 +237,7 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
     ) internal {
         DataTypes.Order storage order = _disputeOrders[intentId];
 
-        // Fill was invalid — maker committed fraud
+        // Fill was invalid — maker committed fraud (or failed to defend).
         // Calculate slash amount via curve
         uint256 makerStake = staking.getStake(commitment.maker);
         uint256 slashAmt = calculateSlashAmount(order.inputAmount, makerStake);
@@ -336,30 +245,25 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         // Snapshot exposure before slash — slashPartial may cap exposure at remaining stake
         uint256 exposureBefore = staking.getExposure(commitment.maker);
 
-        // Partial slash — returns actual slashed amount
+        // Partial slash — returns actual slashed amount (transferred to this contract)
         uint256 actualSlashed = staking.slashPartial(commitment.maker, intentId, slashAmt);
 
-        // Bond: returned to challenger in full
-        // Slashed amount pool: 25% to challenger, 25% to correct attestors, 50% + dust to treasury
+        // Bond returned to challenger in full, plus 25% of the slash.
+        // Remaining 75% (+ dust) to treasury.
         uint256 challengerSlashReward = actualSlashed / 4;
-        uint256 attestorPool = actualSlashed / 4;
+        uint256 treasuryShare = actualSlashed - challengerSlashReward;
 
-        // Use try/catch to prevent a blacklisted challenger from blocking resolution
         uint256 challengerTotal = disp.bondAmount + challengerSlashReward;
-        try bondToken.transfer(disp.challenger, challengerTotal) returns (bool success) {
-            if (success) {
-                emit ChallengerRewarded(disp.challenger, challengerTotal);
-            } else {
-                emit ChallengerRewardFailed(intentId, disp.challenger, challengerTotal);
-            }
-        } catch {
+        if (bondToken.tryTransfer(disp.challenger, challengerTotal)) {
+            emit ChallengerRewarded(disp.challenger, challengerTotal);
+        } else {
             emit ChallengerRewardFailed(intentId, disp.challenger, challengerTotal);
         }
+        if (!bondToken.tryTransfer(treasury, treasuryShare)) {
+            emit TreasuryTransferFailed(intentId, treasuryShare);
+        }
 
-        // Distribute attestor rewards (invalid-side attestors)
-        _distributeAttestorRewards(intentId, false, attestorPool);
-
-        // Refund taker's escrowed funds
+        // Refund taker's escrowed funds.
         // Only decrease exposure by what slashPartial's cap didn't already absorb
         uint256 exposureAfter = staking.getExposure(commitment.maker);
         uint256 alreadyReduced = exposureBefore - exposureAfter;
@@ -372,51 +276,14 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         delete _disputeOrders[intentId];
     }
 
-    function _distributeAttestorRewards(
-        bytes32 intentId,
-        bool validSide,
-        uint256 pool
-    ) internal {
-        address[] storage attestors = validSide ? _validAttestors[intentId] : _invalidAttestors[intentId];
-        uint256 totalWeight = validSide ? _totalValidWeight[intentId] : _totalInvalidWeight[intentId];
-
-        if (totalWeight == 0 || attestors.length == 0) return;
-
-        for (uint256 i = 0; i < attestors.length; i++) {
-            uint256 weight = _attestorStakeWeights[intentId][attestors[i]];
-            uint256 share = (pool * weight) / totalWeight;
-            if (share > 0) {
-                // Use try/catch to prevent a blacklisted attestor from blocking resolution
-                try bondToken.transfer(attestors[i], share) returns (bool success) {
-                    if (success) {
-                        emit AttestorRewarded(intentId, attestors[i], share);
-                    } else {
-                        emit AttestorRewardFailed(intentId, attestors[i], share);
-                    }
-                } catch {
-                    emit AttestorRewardFailed(intentId, attestors[i], share);
-                }
-            }
-        }
-        // Dust stays in contract as treasury
-    }
-
-    // --- Internal helpers ---
-
-    /// @dev Voting-eligible stake: totalActiveStake minus the maker's and challenger's stakes.
-    ///      getStake() returns stakedAmount even for inactive makers whose stake is already
-    ///      excluded from totalActiveStake, so we clamp to zero to prevent underflow.
-    ///      Addition is safe: both values are bounded by real USDC supply (~4e16 at 6 decimals).
-    function _eligibleVotingStake(address maker, address challenger) internal view returns (uint256) {
-        uint256 total = staking.totalActiveStake();
-        uint256 excluded = staking.getStake(maker) + staking.getStake(challenger);
-        return total > excluded ? total - excluded : 0;
-    }
-
     // --- View functions ---
 
     function getDispute(bytes32 intentId) external view returns (DataTypes.Dispute memory) {
         return _disputes[intentId];
+    }
+
+    function getDisputeOrder(bytes32 intentId) external view returns (DataTypes.Order memory) {
+        return _disputeOrders[intentId];
     }
 
     function calculateDisputeBond(uint256 fillAmount) public view returns (uint256) {
@@ -435,17 +302,5 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
 
     function disputeResolutionWindow() external view returns (uint256) {
         return disputeResolutionDuration;
-    }
-
-    function getDisputeAttestors(bytes32 intentId, bool validSide) external view returns (address[] memory) {
-        return validSide ? _validAttestors[intentId] : _invalidAttestors[intentId];
-    }
-
-    function getAttestorStakeWeight(bytes32 intentId, address attestor) external view returns (uint256) {
-        return _attestorStakeWeights[intentId][attestor];
-    }
-
-    function getQuorumFailCount(bytes32 intentId) external view returns (uint256) {
-        return quorumFailCount[intentId];
     }
 }

--- a/contracts/src/interfaces/IGauloiDisputes.sol
+++ b/contracts/src/interfaces/IGauloiDisputes.sol
@@ -9,36 +9,28 @@ interface IGauloiDisputes {
     event DisputeResolved(bytes32 indexed intentId, bool fillValid);
     event ChallengerRewarded(address indexed challenger, uint256 reward);
     event ChallengerBondSlashed(address indexed challenger, uint256 amount);
-    event AttestorRecorded(bytes32 indexed intentId, address indexed attestor, bool fillValid, uint256 stakeWeight);
-    event QuorumExtended(bytes32 indexed intentId, uint256 newDeadline, uint256 failCount);
-    event AttestorRewarded(bytes32 indexed intentId, address indexed attestor, uint256 amount);
-    event AttestorRewardFailed(bytes32 indexed intentId, address indexed attestor, uint256 amount);
     event MakerRewardFailed(bytes32 indexed intentId, address indexed maker, uint256 amount);
     event ChallengerRewardFailed(bytes32 indexed intentId, address indexed challenger, uint256 amount);
+    event TreasuryTransferFailed(bytes32 indexed intentId, uint256 amount);
     event ResolutionWindowUpdated(uint256 oldValue, uint256 newValue);
     event BondParamsUpdated(uint256 newBps, uint256 newMinBond);
     event SlashCurveUpdated(uint256 base, uint256 k, uint256 max);
-    event QuorumUpdated(uint256 oldValue, uint256 newValue);
+    event ResolverUpdated(uint256 indexed destinationChainId, address indexed oldResolver, address indexed newResolver);
+    event TreasuryUpdated(address oldTreasury, address newTreasury);
 
-    // Any staked maker disputes a fill (stores order for later resolution)
-    function dispute(DataTypes.Order calldata order) external;
+    // Anyone challenges a fill claim by posting a bond (permissionless)
+    function challenge(DataTypes.Order calldata order) external;
 
-    // Resolve via stake-weighted EIP-712 signatures from staked makers
-    function resolveDispute(
-        bytes32 intentId,
-        bool fillValid,
-        bytes[] calldata signatures
-    ) external;
+    // Resolve via the corridor's terminal resolver; evidence is resolver-specific
+    function resolve(bytes32 intentId, bytes calldata evidence) external;
 
-    // Finalize unresolved dispute after deadline
+    // Past the deadline with no verdict, the maker failed to defend: fill invalid
     function finalizeExpiredDispute(bytes32 intentId) external;
 
     // --- View functions ---
     function getDispute(bytes32 intentId) external view returns (DataTypes.Dispute memory);
+    function getDisputeOrder(bytes32 intentId) external view returns (DataTypes.Order memory);
     function calculateDisputeBond(uint256 fillAmount) external view returns (uint256);
     function calculateSlashAmount(uint256 fillAmount, uint256 makerTotalStake) external view returns (uint256);
     function disputeResolutionWindow() external view returns (uint256);
-    function getDisputeAttestors(bytes32 intentId, bool validSide) external view returns (address[] memory);
-    function getAttestorStakeWeight(bytes32 intentId, address attestor) external view returns (uint256);
-    function getQuorumFailCount(bytes32 intentId) external view returns (uint256);
 }

--- a/contracts/src/interfaces/IResolver.sol
+++ b/contracts/src/interfaces/IResolver.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {DataTypes} from "../types/DataTypes.sol";
+
+/// @notice Terminal arbiter for disputes on a corridor. Each destination chain is
+///         assigned one resolver in GauloiDisputes: a storage-proof verifier where
+///         the corridor is provable, a named M-of-N council where it is not.
+///         A resolver renders a verdict from evidence; it never moves funds.
+interface IResolver {
+    enum Verdict {
+        Pending, // evidence insufficient — dispute stays open
+        Valid,   // fill satisfied the order — challenger loses bond
+        Invalid  // fill did not happen / did not satisfy the order — maker slashed
+    }
+
+    /// @param intentId The disputed intent
+    /// @param order    The order under dispute (resolver checks fill against its terms)
+    /// @param evidence Resolver-specific: council verdict signatures, storage proof, etc.
+    function resolve(
+        bytes32 intentId,
+        DataTypes.Order calldata order,
+        bytes calldata evidence
+    ) external returns (Verdict);
+}

--- a/contracts/src/libraries/TransferLib.sol
+++ b/contracts/src/libraries/TransferLib.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+library TransferLib {
+    /// @dev Attempt an ERC-20 transfer without letting a reverting or misbehaving
+    ///      token block the caller (e.g. a USDC-blacklisted recipient DoS-ing
+    ///      settlement). Returns true iff the transfer actually succeeded.
+    ///
+    ///      Unlike `try IERC20.transfer() returns (bool)`, this tolerates
+    ///      no-return-data tokens (USDT): a successful call with empty return data
+    ///      counts as success rather than falling into a catch block.
+    function tryTransfer(IERC20 token, address to, uint256 amount) internal returns (bool) {
+        if (address(token).code.length == 0) return false;
+        (bool success, bytes memory data) = address(token).call(
+            abi.encodeCall(IERC20.transfer, (to, amount))
+        );
+        return success && (data.length == 0 || (data.length >= 32 && abi.decode(data, (bool))));
+    }
+}

--- a/contracts/test/fork/ForkSettlement.t.sol
+++ b/contracts/test/fork/ForkSettlement.t.sol
@@ -7,9 +7,10 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {GauloiStaking} from "../../src/GauloiStaking.sol";
 import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
 import {GauloiDisputes} from "../../src/GauloiDisputes.sol";
+import {IResolver} from "../../src/interfaces/IResolver.sol";
+import {MockResolver} from "../helpers/MockResolver.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
 import {IntentLib} from "../../src/libraries/IntentLib.sol";
-import {SignatureLib} from "../../src/libraries/SignatureLib.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /// @notice Fork tests against real Ethereum mainnet USDC and USDT.
@@ -29,6 +30,7 @@ contract ForkSettlementTest is Test {
     GauloiStaking public staking;
     GauloiEscrow public escrow;
     GauloiDisputes public disputes;
+    MockResolver public resolver;
 
     IERC20 public usdc;
     IERC20 public usdt;
@@ -73,8 +75,9 @@ contract ForkSettlementTest is Test {
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), USDC,
-            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, owner
+            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, makeAddr("treasury"), owner
         );
+        resolver = new MockResolver();
 
         // Wire contracts
         vm.startPrank(owner);
@@ -83,6 +86,7 @@ contract ForkSettlementTest is Test {
         escrow.setDisputes(address(disputes));
         escrow.addSupportedToken(USDC);
         escrow.addSupportedToken(USDT);
+        disputes.setResolver(DEST_CHAIN, address(resolver));
         vm.stopPrank();
 
         // Fund accounts from whales
@@ -152,20 +156,6 @@ contract ForkSettlementTest is Test {
             escrow.domainSeparator(), structHash
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(takerKey, digest);
-        return abi.encodePacked(r, s, v);
-    }
-
-    function _signAttestation(
-        uint256 key, bytes32 intentId, bool fillValid,
-        bytes32 fillTxHash, uint256 destChainId
-    ) internal view returns (bytes memory) {
-        bytes32 structHash = SignatureLib.hashAttestation(
-            intentId, fillValid, fillTxHash, destChainId
-        );
-        bytes32 digest = MessageHashUtils.toTypedDataHash(
-            disputes.domainSeparator(), structHash
-        );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
         return abi.encodePacked(r, s, v);
     }
 
@@ -301,33 +291,33 @@ contract ForkSettlementTest is Test {
 
         uint256 makerAStake = staking.getMakerInfo(makerA).stakedAmount;
 
-        // MakerB disputes
+        // MakerB challenges
         uint256 bondAmount = disputes.calculateDisputeBond(20_000e6);
         vm.startPrank(makerB);
         usdc.approve(address(disputes), bondAmount);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
-        // MakerC attests: fill is invalid
-        bytes memory attestSig = _signAttestation(makerCKey, intentId, false, fakeFill, DEST_CHAIN);
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attestSig;
+        // Corridor resolver rules the fill invalid
+        resolver.setVerdict(IResolver.Verdict.Invalid);
 
         uint256 takerBalBefore = usdc.balanceOf(taker);
         uint256 makerBBalBefore = usdc.balanceOf(makerB);
 
-        disputes.resolveDispute(intentId, false, sigs);
+        disputes.resolve(intentId, "");
 
         // Taker refunded
         assertEq(usdc.balanceOf(taker) - takerBalBefore, 20_000e6);
 
-        // MakerB gets bond back + 25% of slashed stake
-        uint256 expectedReward = bondAmount + (makerAStake / 4);
-        assertEq(usdc.balanceOf(makerB) - makerBBalBefore, expectedReward);
+        // Slash curve: 20k fill -> 20k * (2 + 650/20_000) = 40_650e6
+        uint256 expectedSlash = 40_650e6;
 
-        // MakerA slashed
-        assertFalse(staking.isActiveMaker(makerA));
-        assertEq(staking.getMakerInfo(makerA).stakedAmount, 0);
+        // MakerB gets bond back + 25% of the slash
+        assertEq(usdc.balanceOf(makerB) - makerBBalBefore, bondAmount + expectedSlash / 4);
+
+        // MakerA partially slashed, still active above min stake
+        assertEq(staking.getMakerInfo(makerA).stakedAmount, makerAStake - expectedSlash);
+        assertTrue(staking.isActiveMaker(makerA));
     }
 
     // =========================================================================

--- a/contracts/test/gas/GasBenchmark.t.sol
+++ b/contracts/test/gas/GasBenchmark.t.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "../helpers/MockERC20.sol";
+import {MockResolver} from "../helpers/MockResolver.sol";
 import {GauloiStaking} from "../../src/GauloiStaking.sol";
 import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
 import {GauloiDisputes} from "../../src/GauloiDisputes.sol";
+import {IResolver} from "../../src/interfaces/IResolver.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
 import {IntentLib} from "../../src/libraries/IntentLib.sol";
-import {SignatureLib} from "../../src/libraries/SignatureLib.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /// @title Gas Benchmark — isolated per-operation gas measurements
@@ -19,8 +20,10 @@ contract GasBenchmark is Test {
     GauloiStaking staking;
     GauloiEscrow escrow;
     GauloiDisputes disputes;
+    MockResolver resolver;
 
     address owner = makeAddr("owner");
+    address treasury = makeAddr("treasury");
 
     // Taker with private key
     uint256 takerKey = 0x7A4E5;
@@ -57,14 +60,16 @@ contract GasBenchmark is Test {
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), address(usdc),
-            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, owner
+            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, treasury, owner
         );
+        resolver = new MockResolver();
 
         vm.startPrank(owner);
         staking.setEscrow(address(escrow));
         staking.setDisputes(address(disputes));
         escrow.setDisputes(address(disputes));
         escrow.addSupportedToken(address(usdc));
+        disputes.setResolver(DEST_CHAIN_ID, address(resolver));
         vm.stopPrank();
 
         // Fund everyone generously
@@ -174,33 +179,37 @@ contract GasBenchmark is Test {
     //  Disputes
     // ═══════════════════════════════════════════
 
-    function test_gas_dispute() public {
+    function test_gas_challenge() public {
         (, DataTypes.Order memory order) = _setupDisputableIntent();
 
         vm.startPrank(maker2);
         usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
     }
 
-    function test_gas_resolveDispute() public {
+    function test_gas_resolve_valid() public {
         (bytes32 intentId, DataTypes.Order memory order) = _setupDisputableIntent();
 
-        // Maker2 disputes
         vm.startPrank(maker2);
         usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
-        // Maker3 attests fill is valid
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
+        resolver.setVerdict(IResolver.Verdict.Valid);
+        disputes.resolve(intentId, "");
+    }
 
-        disputes.resolveDispute(intentId, true, sigs);
+    function test_gas_resolve_invalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _setupDisputableIntent();
+
+        vm.startPrank(maker2);
+        usdc.approve(address(disputes), type(uint256).max);
+        disputes.challenge(order);
+        vm.stopPrank();
+
+        resolver.setVerdict(IResolver.Verdict.Invalid);
+        disputes.resolve(intentId, "");
     }
 
     function test_gas_finalizeExpiredDispute() public {
@@ -208,70 +217,11 @@ contract GasBenchmark is Test {
 
         vm.startPrank(maker2);
         usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
         vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
         disputes.finalizeExpiredDispute(intentId);
-    }
-
-    function test_gas_resolveDispute_stakeWeighted() public {
-        // 3 attestors with different stakes
-        uint256 maker4Key = 0xD00D;
-        uint256 maker5Key = 0xBAAD;
-        uint256 maker6Key = 0xFACE;
-        address maker4 = vm.addr(maker4Key);
-        address maker5 = vm.addr(maker5Key);
-        address maker6 = vm.addr(maker6Key);
-
-        usdc.mint(maker4, 10_000_000e6);
-        usdc.mint(maker5, 10_000_000e6);
-        usdc.mint(maker6, 10_000_000e6);
-        _stake(maker4, 50_000e6);
-        _stake(maker5, 30_000e6);
-        _stake(maker6, 20_000e6);
-
-        _stake(maker1, 50_000e6);
-        _stake(maker2, 50_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _fillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig4 = _signAttestation(maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-        bytes memory sig5 = _signAttestation(maker5Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-        bytes memory sig6 = _signAttestation(maker6Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-
-        bytes[] memory sigs = new bytes[](3);
-        sigs[0] = sig4;
-        sigs[1] = sig5;
-        sigs[2] = sig6;
-
-        disputes.resolveDispute(intentId, true, sigs);
-    }
-
-    function test_gas_slashPartial() public {
-        _stake(maker1, 50_000e6);
-        _stake(maker2, 50_000e6);
-        _stake(maker3, 50_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _fillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId);
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, false, sigs);
     }
 
     // ═══════════════════════════════════════════
@@ -340,18 +290,5 @@ contract GasBenchmark is Test {
         _stake(maker2, 50_000e6);
         _stake(maker3, 50_000e6);
         return _fillIntent(10_000e6);
-    }
-
-    function _signAttestation(
-        uint256 privateKey,
-        bytes32 intentId,
-        bool fillValid,
-        bytes32 fillTxHash,
-        uint256 destChainId
-    ) internal view returns (bytes memory) {
-        bytes32 structHash = SignatureLib.hashAttestation(intentId, fillValid, fillTxHash, destChainId);
-        bytes32 digest = MessageHashUtils.toTypedDataHash(disputes.domainSeparator(), structHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
-        return abi.encodePacked(r, s, v);
     }
 }

--- a/contracts/test/helpers/MockResolver.sol
+++ b/contracts/test/helpers/MockResolver.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IResolver} from "../../src/interfaces/IResolver.sol";
+import {DataTypes} from "../../src/types/DataTypes.sol";
+
+/// @dev Resolver with a settable verdict; records the last call for assertions
+contract MockResolver is IResolver {
+    Verdict public verdict; // defaults to Pending
+
+    bytes32 public lastIntentId;
+    bytes public lastEvidence;
+    uint256 public lastDestinationChainId;
+    uint256 public callCount;
+
+    function setVerdict(Verdict v) external {
+        verdict = v;
+    }
+
+    function resolve(
+        bytes32 intentId,
+        DataTypes.Order calldata order,
+        bytes calldata evidence
+    ) external returns (Verdict) {
+        lastIntentId = intentId;
+        lastEvidence = evidence;
+        lastDestinationChainId = order.destinationChainId;
+        callCount++;
+        return verdict;
+    }
+}

--- a/contracts/test/integration/SettlementLoop.t.sol
+++ b/contracts/test/integration/SettlementLoop.t.sol
@@ -3,14 +3,15 @@ pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "../helpers/MockERC20.sol";
+import {MockResolver} from "../helpers/MockResolver.sol";
 import {GauloiStaking} from "../../src/GauloiStaking.sol";
 import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
 import {GauloiDisputes} from "../../src/GauloiDisputes.sol";
 import {IGauloiEscrow} from "../../src/interfaces/IGauloiEscrow.sol";
 import {IGauloiDisputes} from "../../src/interfaces/IGauloiDisputes.sol";
+import {IResolver} from "../../src/interfaces/IResolver.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
 import {IntentLib} from "../../src/libraries/IntentLib.sol";
-import {SignatureLib} from "../../src/libraries/SignatureLib.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /// @notice Full integration test: all three contracts deployed and wired together.
@@ -20,8 +21,10 @@ contract SettlementLoopTest is Test {
     GauloiStaking public staking;
     GauloiEscrow public escrow;
     GauloiDisputes public disputes;
+    MockResolver public resolver;
 
     address public owner = makeAddr("owner");
+    address public treasury = makeAddr("treasury");
 
     // Taker with private key for signing
     uint256 public takerKey = 0x7A4E5;
@@ -62,8 +65,9 @@ contract SettlementLoopTest is Test {
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
         disputes = new GauloiDisputes(
             address(staking), address(escrow), address(usdc),
-            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, owner
+            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, treasury, owner
         );
+        resolver = new MockResolver();
 
         // Wire contracts
         vm.startPrank(owner);
@@ -72,6 +76,7 @@ contract SettlementLoopTest is Test {
         escrow.setDisputes(address(disputes));
         escrow.addSupportedToken(address(usdc));
         escrow.addSupportedToken(address(usdt));
+        disputes.setResolver(DEST_CHAIN, address(resolver));
         vm.stopPrank();
 
         // Fund participants
@@ -136,20 +141,6 @@ contract SettlementLoopTest is Test {
             escrow.domainSeparator(), structHash
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(takerKey, digest);
-        return abi.encodePacked(r, s, v);
-    }
-
-    function _signAttestation(
-        uint256 key, bytes32 intentId, bool fillValid,
-        bytes32 fillTxHash, uint256 destChainId
-    ) internal view returns (bytes memory) {
-        bytes32 structHash = SignatureLib.hashAttestation(
-            intentId, fillValid, fillTxHash, destChainId
-        );
-        bytes32 digest = MessageHashUtils.toTypedDataHash(
-            disputes.domainSeparator(), structHash
-        );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
         return abi.encodePacked(r, s, v);
     }
 
@@ -284,28 +275,27 @@ contract SettlementLoopTest is Test {
         vm.prank(makerA);
         escrow.submitFill(intentId, fillTx);
 
-        // MakerB disputes (incorrectly)
+        // MakerB challenges (incorrectly)
         uint256 bondAmount = disputes.calculateDisputeBond(20_000e6);
         uint256 makerBBalBefore = usdc.balanceOf(makerB);
 
         vm.startPrank(makerB);
         usdc.approve(address(disputes), bondAmount);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
         assertEq(usdc.balanceOf(makerB), makerBBalBefore - bondAmount);
 
-        // MakerC attests: fill is valid
-        bytes memory attestSig = _signAttestation(makerCKey, intentId, true, fillTx, DEST_CHAIN);
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attestSig;
+        // Corridor resolver rules the fill valid (maker defends successfully)
+        resolver.setVerdict(IResolver.Verdict.Valid);
 
         uint256 makerABalBefore = usdc.balanceOf(makerA);
 
-        disputes.resolveDispute(intentId, true, sigs);
+        disputes.resolve(intentId, "");
 
-        // MakerA gets escrowed funds + half the bond
+        // MakerA gets escrowed funds + half the bond; treasury gets the rest
         assertEq(usdc.balanceOf(makerA) - makerABalBefore, 20_000e6 + bondAmount / 2);
+        assertEq(usdc.balanceOf(treasury), bondAmount - bondAmount / 2);
 
         // Intent settled
         assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
@@ -328,22 +318,20 @@ contract SettlementLoopTest is Test {
         vm.prank(makerA);
         escrow.submitFill(intentId, fakeFillTx);
 
-        // MakerB disputes (correctly)
+        // MakerB challenges (correctly)
         uint256 bondAmount = disputes.calculateDisputeBond(20_000e6);
         vm.startPrank(makerB);
         usdc.approve(address(disputes), bondAmount);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
-        // MakerC attests: fill is invalid
-        bytes memory attestSig = _signAttestation(makerCKey, intentId, false, fakeFillTx, DEST_CHAIN);
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attestSig;
+        // Corridor resolver rules the fill invalid
+        resolver.setVerdict(IResolver.Verdict.Invalid);
 
         uint256 takerBalBefore = usdc.balanceOf(taker);
         uint256 makerBBalBefore = usdc.balanceOf(makerB);
 
-        disputes.resolveDispute(intentId, false, sigs);
+        disputes.resolve(intentId, "");
 
         // Taker gets escrowed funds back
         assertEq(usdc.balanceOf(taker) - takerBalBefore, 20_000e6);
@@ -365,10 +353,10 @@ contract SettlementLoopTest is Test {
     }
 
     // =========================================================================
-    // Dispute: expires without resolution (defaults to fill-valid)
+    // Dispute: expires without a verdict — maker failed to defend, fill invalid
     // =========================================================================
 
-    function test_dispute_expiresDefault_fillValid() public {
+    function test_dispute_expiresUndefended_fillInvalid() public {
         DataTypes.Order memory order = _makeOrder(address(usdc), 10_000e6, address(usdc), 9_990e6);
         bytes memory sig = _signOrder(order);
 
@@ -381,18 +369,23 @@ contract SettlementLoopTest is Test {
         uint256 bondAmount = disputes.calculateDisputeBond(10_000e6);
         vm.startPrank(makerB);
         usdc.approve(address(disputes), bondAmount);
-        disputes.dispute(order);
+        disputes.challenge(order);
         vm.stopPrank();
 
-        // Nobody resolves. Wait for deadline.
+        // No verdict lands. Wait for deadline.
         vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
 
-        uint256 makerABalBefore = usdc.balanceOf(makerA);
+        uint256 takerBalBefore = usdc.balanceOf(taker);
+        uint256 makerBBalBefore = usdc.balanceOf(makerB);
         disputes.finalizeExpiredDispute(intentId);
 
-        // Defaults to fill-valid: maker gets escrowed funds + half bond
-        assertEq(usdc.balanceOf(makerA) - makerABalBefore, 10_000e6 + bondAmount / 2);
-        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
+        // Maker must defend; silence convicts. Taker refunded, maker slashed.
+        // Slash: 10k fill → 10k * (2 + 650/10_000) = 20_650e6
+        uint256 expectedSlash = 20_650e6;
+        assertEq(usdc.balanceOf(taker) - takerBalBefore, 10_000e6);
+        assertEq(usdc.balanceOf(makerB) - makerBBalBefore, bondAmount + expectedSlash / 4);
+        assertEq(staking.getMakerInfo(makerA).stakedAmount, 100_000e6 - expectedSlash);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Expired);
     }
 
     // =========================================================================

--- a/contracts/test/unit/GauloiDisputes.t.sol
+++ b/contracts/test/unit/GauloiDisputes.t.sol
@@ -2,40 +2,35 @@
 pragma solidity ^0.8.24;
 
 import {BaseTest} from "../helpers/BaseTest.sol";
+import {MockERC20} from "../helpers/MockERC20.sol";
+import {MockResolver} from "../helpers/MockResolver.sol";
+import {MockBlacklistableERC20} from "../helpers/MockBlacklistableERC20.sol";
+import {GauloiStaking} from "../../src/GauloiStaking.sol";
+import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
 import {GauloiDisputes} from "../../src/GauloiDisputes.sol";
 import {IGauloiDisputes} from "../../src/interfaces/IGauloiDisputes.sol";
+import {IResolver} from "../../src/interfaces/IResolver.sol";
 import {DataTypes} from "../../src/types/DataTypes.sol";
-import {SignatureLib} from "../../src/libraries/SignatureLib.sol";
 import {IntentLib} from "../../src/libraries/IntentLib.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 contract GauloiDisputesTest is BaseTest {
     GauloiDisputes public disputes;
+    MockResolver public resolver;
 
-    // Use actual private keys for signing (makers)
-    uint256 public maker1Key = 0xA11CE;
-    uint256 public maker2Key = 0xB0B;
-    uint256 public maker3Key = 0xCAFE;
-    address public maker1Addr;
-    address public maker2Addr;
-    address public maker3Addr;
+    address public maker1Addr = makeAddr("disputeMaker1");
+    address public maker2Addr = makeAddr("disputeMaker2");
+    address public challenger = makeAddr("challenger"); // NOT a staked maker
+    address public treasury = makeAddr("treasury");
 
     uint256 public constant RESOLUTION_WINDOW = 24 hours;
     uint256 public constant BOND_BPS = 200; // 2%
     uint256 public constant MIN_BOND = 250e6; // 250 USDC
 
     function setUp() public {
-        // Derive addresses from keys
-        maker1Addr = vm.addr(maker1Key);
-        maker2Addr = vm.addr(maker2Key);
-        maker3Addr = vm.addr(maker3Key);
-
-        // Override the BaseTest taker with our keyed address
         taker = vm.addr(takerKey);
 
-        usdc = new MockERC20Harness("USD Coin", "USDC", 6);
+        usdc = new MockERC20("USD Coin", "USDC", 6);
         staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
-
         escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
 
         disputes = new GauloiDisputes(
@@ -45,29 +40,38 @@ contract GauloiDisputesTest is BaseTest {
             RESOLUTION_WINDOW,
             BOND_BPS,
             MIN_BOND,
+            treasury,
             owner
         );
+
+        resolver = new MockResolver();
 
         vm.startPrank(owner);
         staking.setEscrow(address(escrow));
         staking.setDisputes(address(disputes));
         escrow.setDisputes(address(disputes));
         escrow.addSupportedToken(address(usdc));
+        disputes.setResolver(DEST_CHAIN_ID, address(resolver));
         vm.stopPrank();
 
-        // Fund and stake makers
+        // Fund and stake makers; fund the (non-maker) challenger and taker
         usdc.mint(maker1Addr, 1_000_000e6);
         usdc.mint(maker2Addr, 1_000_000e6);
-        usdc.mint(maker3Addr, 1_000_000e6);
+        usdc.mint(challenger, 1_000_000e6);
         usdc.mint(taker, 1_000_000e6);
 
         _stakeWithAddr(maker1Addr, 50_000e6);
         _stakeWithAddr(maker2Addr, 50_000e6);
-        _stakeWithAddr(maker3Addr, 50_000e6);
 
-        // Approve escrow to pull from taker
+        // Approvals
         vm.prank(taker);
         usdc.approve(address(escrow), type(uint256).max);
+        vm.prank(challenger);
+        usdc.approve(address(disputes), type(uint256).max);
+        vm.prank(maker2Addr);
+        usdc.approve(address(disputes), type(uint256).max);
+        vm.prank(taker);
+        usdc.approve(address(disputes), type(uint256).max);
     }
 
     function _stakeWithAddr(address maker, uint256 amount) internal {
@@ -81,2265 +85,550 @@ contract GauloiDisputesTest is BaseTest {
         DataTypes.Order memory order = _makeOrder(amount, amount - 10e6);
         bytes memory sig = _signOrder(takerKey, order);
 
-        // Maker1 executes and fills
         vm.prank(maker1Addr);
         bytes32 intentId = escrow.executeOrder(order, sig);
 
-        vm.startPrank(maker1Addr);
+        vm.prank(maker1Addr);
         escrow.submitFill(intentId, keccak256("dest_tx"));
-        vm.stopPrank();
 
         return (intentId, order);
     }
 
-    function _signAttestation(
-        uint256 privateKey,
-        bytes32 intentId,
-        bool fillValid,
-        bytes32 fillTxHash,
-        uint256 destChainId
-    ) internal view returns (bytes memory) {
-        bytes32 structHash = SignatureLib.hashAttestation(
-            intentId, fillValid, fillTxHash, destChainId
-        );
-        bytes32 digest = MessageHashUtils.toTypedDataHash(
-            disputes.domainSeparator(), structHash
-        );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
-        return abi.encodePacked(r, s, v);
+    function _challengeAs(address who, DataTypes.Order memory order) internal returns (bytes32) {
+        vm.prank(who);
+        disputes.challenge(order);
+        return IntentLib.computeIntentId(order);
     }
 
-    // --- Dispute creation ---
+    // =========================================================================
+    // challenge()
+    // =========================================================================
 
-    function test_dispute() public {
+    function test_challenge() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        uint256 bond = disputes.calculateDisputeBond(10_000e6);
+        uint256 balBefore = usdc.balanceOf(challenger);
 
+        vm.expectEmit(true, true, false, true);
+        emit IGauloiDisputes.DisputeRaised(intentId, challenger, bond);
+        _challengeAs(challenger, order);
+
+        // Bond pulled
+        assertEq(usdc.balanceOf(challenger), balBefore - bond);
+
+        // Dispute stored
         DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertEq(disp.challenger, maker2Addr);
-        assertEq(disp.bondAmount, 250e6); // 2% of 10k = 200 USDC < 250 min, so use min
+        assertEq(disp.challenger, challenger);
+        assertEq(disp.bondAmount, bond);
+        assertEq(disp.disputeDeadline, block.timestamp + RESOLUTION_WINDOW);
         assertFalse(disp.resolved);
 
-        // Commitment should be Disputed
+        // Order stored for resolution
+        assertEq(disputes.getDisputeOrder(intentId).inputAmount, 10_000e6);
+
+        // Escrow state transitioned
         assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Disputed);
     }
 
-    function test_dispute_bondCalculation() public view {
-        // For 100k fill: 2% = 2000 USDC > 250 min
+    function test_challenge_permissionless_takerCanChallenge() public {
+        // The taker — the victim of a fraudulent fill — needs no maker stake
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+
+        vm.prank(taker);
+        disputes.challenge(order);
+
+        assertEq(disputes.getDispute(intentId).challenger, taker);
+    }
+
+    function test_challenge_revertsIfNotFilled() public {
+        // Committed but not filled
+        DataTypes.Order memory order = _makeOrder(10_000e6, 9_990e6);
+        bytes memory sig = _signOrder(takerKey, order);
+        vm.prank(maker1Addr);
+        escrow.executeOrder(order, sig);
+
+        vm.prank(challenger);
+        vm.expectRevert("GauloiDisputes: not filled");
+        disputes.challenge(order);
+    }
+
+    function test_challenge_revertsIfWindowClosed() public {
+        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+
+        vm.warp(block.timestamp + SETTLEMENT_WINDOW);
+
+        vm.prank(challenger);
+        vm.expectRevert("GauloiDisputes: window closed");
+        disputes.challenge(order);
+    }
+
+    function test_challenge_revertsIfAlreadyChallenged() public {
+        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+
+        _challengeAs(challenger, order);
+
+        vm.prank(maker2Addr);
+        vm.expectRevert("GauloiDisputes: already challenged");
+        disputes.challenge(order);
+    }
+
+    function test_challenge_revertsOnSelfChallenge() public {
+        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+
+        vm.startPrank(maker1Addr);
+        usdc.approve(address(disputes), type(uint256).max);
+        vm.expectRevert("GauloiDisputes: cannot challenge own fill");
+        disputes.challenge(order);
+        vm.stopPrank();
+    }
+
+    function test_challenge_revertsWithoutBond() public {
+        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+
+        address broke = makeAddr("broke");
+        vm.prank(broke);
+        vm.expectRevert();
+        disputes.challenge(order);
+    }
+
+    function test_calculateDisputeBond() public view {
+        // 2% of 100k = 2000 > 250 min
         assertEq(disputes.calculateDisputeBond(100_000e6), 2_000e6);
-        // For 1k fill: 2% = 20 USDC < 250 min, so use min
+        // 2% of 1k = 20 < 250 min → min applies
         assertEq(disputes.calculateDisputeBond(1_000e6), MIN_BOND);
     }
 
-    function test_dispute_notActiveMaker_reverts() public {
-        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+    // =========================================================================
+    // resolve() — verdict Valid
+    // =========================================================================
 
-        address nobody = makeAddr("nobody");
-        usdc.mint(nobody, 1_000e6);
-
-        vm.startPrank(nobody);
-        usdc.approve(address(disputes), type(uint256).max);
-        vm.expectRevert("GauloiDisputes: not active maker");
-        disputes.dispute(order);
-        vm.stopPrank();
-    }
-
-    function test_dispute_ownFill_reverts() public {
-        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-
-        vm.startPrank(maker1Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        vm.expectRevert("GauloiDisputes: cannot dispute own fill");
-        disputes.dispute(order);
-        vm.stopPrank();
-    }
-
-    function test_dispute_alreadyDisputed_reverts() public {
-        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        vm.startPrank(maker3Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        vm.expectRevert("GauloiDisputes: already disputed");
-        disputes.dispute(order);
-        vm.stopPrank();
-    }
-
-    function test_dispute_afterWindowClosed_reverts() public {
-        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-
-        vm.warp(block.timestamp + SETTLEMENT_WINDOW + 1);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        vm.expectRevert("GauloiDisputes: window closed");
-        disputes.dispute(order);
-        vm.stopPrank();
-    }
-
-    // --- Dispute resolution: fill valid ---
-
-    function test_resolveDispute_fillValid() public {
+    function test_resolve_valid() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        uint256 bond = disputes.calculateDisputeBond(10_000e6);
+        _challengeAs(challenger, order);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        resolver.setVerdict(IResolver.Verdict.Valid);
 
-        // Maker3 attests fill is valid
-        // maker3 has 50k stake. Eligible = totalActive(150k) - maker1(50k) - maker2(50k) = 50k
-        // maker3's 50k = 100% of eligible → quorum (30%) met
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
+        uint256 makerBefore = usdc.balanceOf(maker1Addr);
+        uint256 treasuryBefore = usdc.balanceOf(treasury);
 
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
+        vm.expectEmit(true, false, false, true);
+        emit IGauloiDisputes.DisputeResolved(intentId, true);
+        disputes.resolve(intentId, "");
 
-        uint256 maker1BalBefore = usdc.balanceOf(maker1Addr);
-        uint256 maker3BalBefore = usdc.balanceOf(maker3Addr);
+        // Maker: escrowed funds + half the bond
+        assertEq(usdc.balanceOf(maker1Addr) - makerBefore, 10_000e6 + bond / 2);
+        // Treasury: other half
+        assertEq(usdc.balanceOf(treasury) - treasuryBefore, bond - bond / 2);
 
-        disputes.resolveDispute(intentId, true, sigs);
-
+        // State
         DataTypes.Dispute memory disp = disputes.getDispute(intentId);
         assertTrue(disp.resolved);
         assertTrue(disp.fillDeemedValid);
-
-        uint256 bondAmount = disputes.calculateDisputeBond(10_000e6); // 250e6 (min)
-        // Maker1 gets escrowed funds + 50% of bond
-        uint256 maker1BalAfter = usdc.balanceOf(maker1Addr);
-        assertEq(maker1BalAfter - maker1BalBefore, 10_000e6 + bondAmount / 2);
-
-        // Maker3 gets 25% of bond as attestor reward
-        uint256 maker3BalAfter = usdc.balanceOf(maker3Addr);
-        assertEq(maker3BalAfter - maker3BalBefore, bondAmount / 4);
-
-        // Intent settled
         assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
+        assertEq(staking.getExposure(maker1Addr), 0);
+
+        // Order storage reclaimed
+        assertEq(disputes.getDisputeOrder(intentId).taker, address(0));
     }
 
-    // --- Dispute resolution: fill invalid ---
-
-    function test_resolveDispute_fillInvalid() public {
+    function test_resolve_valid_anyoneCanSubmit() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Valid);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        vm.prank(makeAddr("randomKeeper"));
+        disputes.resolve(intentId, "");
 
-        // Maker3 attests fill is invalid
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        uint256 takerBalBefore = usdc.balanceOf(taker);
-        uint256 challengerBalBefore = usdc.balanceOf(maker2Addr);
-
-        disputes.resolveDispute(intentId, false, sigs);
-
-        // Taker gets escrowed funds back
-        assertEq(usdc.balanceOf(taker) - takerBalBefore, 10_000e6);
-
-        // Slash curve: 10k fill → multiplier = 2 + 650e6/10_000e6 = 2.065
-        // slashAmt = 10_000e6 * 2.065 = 20_650e6
-        uint256 expectedSlash = 20_650e6;
-
-        // Challenger gets bond back + 25% of slashed amount
-        uint256 bondAmount = disputes.calculateDisputeBond(10_000e6);
-        uint256 expectedChallengerReward = bondAmount + (expectedSlash / 4);
-        assertEq(usdc.balanceOf(maker2Addr) - challengerBalBefore, expectedChallengerReward);
-
-        // Maker1 keeps remaining stake
-        DataTypes.MakerInfo memory maker1Info = staking.getMakerInfo(maker1Addr);
-        assertEq(maker1Info.stakedAmount, 50_000e6 - expectedSlash);
-        assertTrue(maker1Info.isActive); // Still above 10k min
+        assertTrue(disputes.getDispute(intentId).resolved);
     }
 
-    // --- Signature verification ---
+    // =========================================================================
+    // resolve() — verdict Invalid
+    // =========================================================================
 
-    function test_resolveDispute_duplicateSigner_reverts() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+    function test_resolve_invalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(20_000e6);
+        uint256 bond = disputes.calculateDisputeBond(20_000e6);
+        _challengeAs(challenger, order);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        resolver.setVerdict(IResolver.Verdict.Invalid);
 
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
+        uint256 takerBefore = usdc.balanceOf(taker);
+        uint256 challengerBefore = usdc.balanceOf(challenger);
+        uint256 treasuryBefore = usdc.balanceOf(treasury);
 
-        bytes[] memory sigs = new bytes[](2);
-        sigs[0] = sig;
-        sigs[1] = sig; // Duplicate
+        disputes.resolve(intentId, "");
 
-        vm.expectRevert("GauloiDisputes: already attested");
-        disputes.resolveDispute(intentId, true, sigs);
-    }
+        // Taker refunded from escrow
+        assertEq(usdc.balanceOf(taker) - takerBefore, 20_000e6);
 
-    function test_resolveDispute_makerCannotAttestOwn_reverts() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        // Slash curve: 20k fill → multiplier = 2 + 650e6/20_000e6 = 2.0325 → 40_650e6
+        uint256 expectedSlash = 40_650e6;
+        assertEq(staking.getStake(maker1Addr), 50_000e6 - expectedSlash);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        // Challenger: bond back + 25% of slash
+        assertEq(usdc.balanceOf(challenger) - challengerBefore, bond + expectedSlash / 4);
 
-        // Maker1 (the disputed maker) tries to attest their own fill
-        bytes memory sig = _signAttestation(
-            maker1Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
+        // Treasury: 75% of slash
+        assertEq(usdc.balanceOf(treasury) - treasuryBefore, expectedSlash - expectedSlash / 4);
 
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        vm.expectRevert("GauloiDisputes: maker cannot attest own fill");
-        disputes.resolveDispute(intentId, true, sigs);
-    }
-
-    function test_resolveDispute_challengerCannotAttest_reverts() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Maker2 (challenger) tries to attest
-        bytes memory sig = _signAttestation(
-            maker2Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        vm.expectRevert("GauloiDisputes: challenger cannot attest");
-        disputes.resolveDispute(intentId, true, sigs);
-    }
-
-    // --- Expired dispute (defaults to fill-valid) ---
-
-    function test_finalizeExpiredDispute() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-
-        uint256 maker1BalBefore = usdc.balanceOf(maker1Addr);
-
-        disputes.finalizeExpiredDispute(intentId);
-
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
-
-        // Zero attestations → default fill-valid
-        // Maker gets escrowed funds + 50% of bond (no attestor rewards since no attestors)
-        uint256 bondAmount = disputes.calculateDisputeBond(10_000e6);
-        assertEq(usdc.balanceOf(maker1Addr) - maker1BalBefore, 10_000e6 + bondAmount / 2);
-    }
-
-    function test_finalizeExpiredDispute_beforeDeadline_reverts() public {
-        (, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        bytes32 intentId = IntentLib.computeIntentId(order);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        vm.expectRevert("GauloiDisputes: deadline not passed");
-        disputes.finalizeExpiredDispute(intentId);
-    }
-
-    function test_resolveDispute_fillValid_cleansOrderStorage() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // _disputes should still be preserved for audit trail
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
-        assertEq(disp.challenger, maker2Addr);
-    }
-
-    function test_resolveDispute_fillInvalid_cleansOrderStorage() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, false, sigs);
-
-        // _disputes preserved
+        // State
         DataTypes.Dispute memory disp = disputes.getDispute(intentId);
         assertTrue(disp.resolved);
         assertFalse(disp.fillDeemedValid);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Expired);
+        assertEq(staking.getExposure(maker1Addr), 0);
     }
 
-    function test_finalizeExpiredDispute_cleansOrderStorage() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+    function test_resolve_invalid_slashExceedsStake() public {
+        // 30k fill: slash = 30k * (2 + 650/30000) ≈ 60_650e6 > 50k stake → full stake
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(30_000e6);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Invalid);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        uint256 takerBefore = usdc.balanceOf(taker);
 
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
+        disputes.resolve(intentId, "");
 
-        disputes.finalizeExpiredDispute(intentId);
+        // Full stake slashed, maker deactivated, exposure fully absorbed by cap
+        assertEq(staking.getStake(maker1Addr), 0);
+        assertFalse(staking.isActiveMaker(maker1Addr));
+        assertEq(staking.getExposure(maker1Addr), 0);
 
-        // _disputes preserved
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
+        // Taker still made whole from escrow
+        assertEq(usdc.balanceOf(taker) - takerBefore, 30_000e6);
     }
 
-    function test_resolveDispute_afterDeadline_reverts() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+    // =========================================================================
+    // resolve() — guards
+    // =========================================================================
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+    function test_resolve_revertsOnPendingVerdict() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+        _challengeAs(challenger, order);
+
+        // MockResolver defaults to Pending
+        vm.expectRevert("GauloiDisputes: no verdict");
+        disputes.resolve(intentId, "");
+    }
+
+    function test_resolve_revertsIfNoDispute() public {
+        vm.expectRevert("GauloiDisputes: no dispute");
+        disputes.resolve(keccak256("nothing"), "");
+    }
+
+    function test_resolve_revertsIfAlreadyResolved() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Valid);
+        disputes.resolve(intentId, "");
+
+        vm.expectRevert("GauloiDisputes: already resolved");
+        disputes.resolve(intentId, "");
+    }
+
+    function test_resolve_revertsAfterDeadline() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Valid);
 
         vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
 
         vm.expectRevert("GauloiDisputes: deadline passed");
-        disputes.resolveDispute(intentId, true, sigs);
+        disputes.resolve(intentId, "");
     }
 
-    // ═══════════════════════════════════════════
-    //  Phase A: New tests
-    // ═══════════════════════════════════════════
-
-    // --- Slash curve ---
-
-    function test_slashCurve_smallFill() public {
-        // $50 fill → multiplier = 2 + 650e6/50e6 = 2 + 13 = 15 (capped at max 15)
-        // slashAmt = 50e6 * 15 = 750e6
-        uint256 slash = disputes.calculateSlashAmount(50e6, 100_000e6);
-        assertEq(slash, 750e6);
-    }
-
-    function test_slashCurve_mediumFill() public {
-        // $500 fill → multiplier = 2 + 650e6/500e6 = 2 + 1.3 = 3.3
-        // slashAmt = 500e6 * 3.3 = 1,650e6
-        uint256 slash = disputes.calculateSlashAmount(500e6, 100_000e6);
-        assertEq(slash, 1_650e6);
-    }
-
-    function test_slashCurve_largeFill() public {
-        // $50k fill → multiplier = 2 + 650e6/50_000e6 = 2 + 0.013 = 2.013
-        // slashAmt = 50_000e6 * 2.013 = 100,650e6 → capped at stake 50k
-        uint256 slash = disputes.calculateSlashAmount(50_000e6, 50_000e6);
-        assertEq(slash, 50_000e6); // Capped at stake
-    }
-
-    function test_calculateSlashAmount_view() public view {
-        // Verify the fixed-point math against spec reference values
-        // $5,000 fill → multiplier = 2 + 650e6/5_000e6 = 2 + 0.13 = 2.13
-        // slashAmt = 5_000e6 * 2.13 = 10,650e6
-        assertEq(disputes.calculateSlashAmount(5_000e6, 100_000e6), 10_650e6);
-
-        // $50,000 fill → multiplier = 2 + 650e6/50_000e6 = 2.013
-        // slashAmt = 50_000e6 * 2.013 = 100,650e6
-        assertEq(disputes.calculateSlashAmount(50_000e6, 200_000e6), 100_650e6);
-    }
-
-    // --- Quorum ---
-
-    function test_quorumNotMet_noResolution() public {
-        // Set up: maker4 with small stake so quorum isn't met
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6); // Small stake
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // maker4 attests (10k stake). Eligible = 160k - 50k(maker1) - 50k(maker2) = 60k
-        // Quorum needs 30% of 60k = 18k. maker4 only has 10k → not met
-        bytes memory sig = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Should NOT be resolved yet
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertFalse(disp.resolved);
-    }
-
-    function test_quorumMet_resolves() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // maker3 has 50k stake. Eligible = 150k - 50k(maker1) - 50k(maker2) = 50k
-        // Quorum needs 30% of 50k = 15k. maker3 has 50k → met
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, true, sigs);
-
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
-    }
-
-    function test_competingVotes() public {
-        // Add maker4 to have more attestors
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 50_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Eligible = 200k - 50k(maker1) - 50k(maker2) = 100k
-        // Quorum = 30% of 100k = 30k
-
-        // maker3 votes valid (50k)
-        bytes memory sigValid = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs1 = new bytes[](1);
-        sigs1[0] = sigValid;
-        disputes.resolveDispute(intentId, true, sigs1);
-
-        // Not resolved yet — quorum met (50k >= 30k) but need to check majority
-        // Valid weight: 50k, Invalid: 0, Total: 50k → majority met, actually resolved
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved); // Valid wins with majority
-        assertTrue(disp.fillDeemedValid);
-    }
-
-    // --- Attestor recording ---
-
-    function test_attestorRecording() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Verify recording
-        address[] memory validAttestors = disputes.getDisputeAttestors(intentId, true);
-        assertEq(validAttestors.length, 1);
-        assertEq(validAttestors[0], maker3Addr);
-        assertEq(disputes.getAttestorStakeWeight(intentId, maker3Addr), 50_000e6);
-
-        address[] memory invalidAttestors = disputes.getDisputeAttestors(intentId, false);
-        assertEq(invalidAttestors.length, 0);
-    }
-
-    // --- Attestor rewards ---
-
-    function test_attestorRewards_fillValid() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker3BalBefore = usdc.balanceOf(maker3Addr);
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, true, sigs);
-
-        uint256 bondAmount = disputes.calculateDisputeBond(10_000e6);
-        // 25% of bond goes to attestors
-        assertEq(usdc.balanceOf(maker3Addr) - maker3BalBefore, bondAmount / 4);
-    }
-
-    function test_attestorRewards_fillInvalid() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker3BalBefore = usdc.balanceOf(maker3Addr);
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, false, sigs);
-
-        // Slash amount: 10k fill → 20,650 USDC
-        uint256 expectedSlash = 20_650e6;
-        // 25% of slashed to attestors
-        assertEq(usdc.balanceOf(maker3Addr) - maker3BalBefore, expectedSlash / 4);
-    }
-
-    function test_attestorRewards_multipleAttestors() public {
-        // Add maker4 with different stake
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 30_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Record balances before
-        uint256 maker3BalBefore = usdc.balanceOf(maker3Addr);
-        uint256 maker4BalBefore = usdc.balanceOf(maker4Addr);
-
-        // maker3 (50k) and maker4 (30k) both attest valid
-        {
-            bytes memory sig3 = _signAttestation(
-                maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes memory sig4 = _signAttestation(
-                maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](2);
-            sigs[0] = sig3;
-            sigs[1] = sig4;
-
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-
-        uint256 attestorPool = disputes.calculateDisputeBond(10_000e6) / 4;
-
-        // Pro-rata: maker3 gets 50k/(50k+30k) * pool, maker4 gets 30k/(50k+30k) * pool
-        assertEq(usdc.balanceOf(maker3Addr) - maker3BalBefore, (attestorPool * 50_000e6) / 80_000e6);
-        assertEq(usdc.balanceOf(maker4Addr) - maker4BalBefore, (attestorPool * 30_000e6) / 80_000e6);
-    }
-
-    // --- Double attestation ---
-
-    function test_doubleAttestation_reverts() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        // Add maker4 so quorum isn't immediately met
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // maker4 attests first (won't meet quorum)
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs1 = new bytes[](1);
-        sigs1[0] = sig4;
-        disputes.resolveDispute(intentId, true, sigs1);
-
-        // maker4 tries to attest again in a separate call
-        vm.expectRevert("GauloiDisputes: already attested");
-        disputes.resolveDispute(intentId, true, sigs1);
-    }
-
-    // --- Quorum failure ---
-
-    function test_quorumFailure_extendsDeadline() public {
-        // Only maker3 is eligible with 50k, but we need quorum to NOT be met
-        // Set quorum to 90% so maker3's 50k out of 50k eligible would barely matter
-        // Actually, with current setup eligible=50k and maker3=50k, quorum always met
-        // Instead: add maker4 with small stake, set higher quorum, make only maker4 attest
-
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6);
-
-        // Set quorum to 50% so 10k out of 60k eligible = ~16.7% < 50%
-        vm.prank(owner);
-        disputes.setQuorumParams(5000);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Only maker4 attests (10k out of 60k eligible = 16.7% < 50% quorum)
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig4;
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Not resolved
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Warp past deadline
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-
-        // Finalize — should extend deadline (first quorum failure)
-        disputes.finalizeExpiredDispute(intentId);
-
-        assertEq(disputes.getQuorumFailCount(intentId), 1);
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Deadline was extended
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertGt(disp.disputeDeadline, block.timestamp);
-    }
-
-    function test_quorumFailure_secondFailure_pauses() public {
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6);
-
-        // Set quorum to 50%
-        vm.prank(owner);
-        disputes.setQuorumParams(5000);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Only maker4 attests — insufficient for quorum
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig4;
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // First expiry — extends deadline
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-        disputes.finalizeExpiredDispute(intentId);
-        assertEq(disputes.getQuorumFailCount(intentId), 1);
-
-        // Second expiry — pauses escrow
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-        disputes.finalizeExpiredDispute(intentId);
-        assertEq(disputes.getQuorumFailCount(intentId), 2);
-
-        // Escrow should be paused
-        assertTrue(escrow.paused());
-
-        // Dispute should be resolved as fill-valid (default)
-        assertTrue(disputes.getDispute(intentId).resolved);
-        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
-    }
-
-    // --- Partial slash scenarios ---
-
-    function test_partialSlash_makerRemainsActive() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, false, sigs);
-
-        // Slash = 20,650 USDC. Maker1 had 50k. Remaining = 29,350 > 10k min
-        assertTrue(staking.isActiveMaker(maker1Addr));
-        assertEq(staking.getStake(maker1Addr), 50_000e6 - 20_650e6);
-    }
-
-    function test_partialSlash_makerDeactivated() public {
-        // Maker1 has exactly 12k stake — slash will bring below 10k min
-        // First we need a maker with lower stake
-        uint256 maker5Key = 0xBAAD;
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker5Addr, 12_000e6);
-
-        // Create intent with maker5
-        DataTypes.Order memory order = _makeOrder(1_000e6, 990e6);
-        bytes memory orderSig = _signOrder(takerKey, order);
-
-        vm.prank(maker5Addr);
-        bytes32 intentId = escrow.executeOrder(order, orderSig);
-
-        vm.prank(maker5Addr);
-        escrow.submitFill(intentId, keccak256("dest_tx"));
-
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Slash for $1k fill: multiplier = 2 + 650e6/1_000e6 = 2.65
-        // slashAmt = 1000e6 * 2.65 = 2,650e6
-        // maker5 remaining = 12k - 2.65k = 9,350 < 10k min → deactivated
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-
-        disputes.resolveDispute(intentId, false, sigs);
-
-        assertFalse(staking.isActiveMaker(maker5Addr));
-        assertEq(staking.getStake(maker5Addr), 12_000e6 - 2_650e6);
-    }
-
-    // --- Expired dispute edge cases ---
-
-    function test_expiredDispute_zeroAttestations_defaultValid() public {
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-
-        disputes.finalizeExpiredDispute(intentId);
-
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
-    }
-
-    function test_expiredDispute_quorumMet_pluralityWins() public {
-        // Plurality path: quorum met, no strict majority, deadline expires.
-        // Need votes on BOTH sides so neither has >50%. This requires:
-        //   1. First call adds votes on one side (doesn't hit quorum alone OR hits quorum but no majority)
-        //   2. Second call adds votes on other side, still no majority
-        //   3. Deadline expires → finalizeExpiredDispute uses plurality
-
-        // Use 4 additional makers with carefully chosen stakes
-        uint256 maker4Key = 0xD00D;
-        uint256 maker5Key = 0xBAAD;
-        uint256 maker6Key = 0xFACE;
-        uint256 maker7Key = 0xDEAF;
-        address maker4Addr = vm.addr(maker4Key);
-        address maker5Addr = vm.addr(maker5Key);
-        address maker6Addr = vm.addr(maker6Key);
-        address maker7Addr = vm.addr(maker7Key);
-
-        usdc.mint(maker4Addr, 1_000_000e6);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        usdc.mint(maker6Addr, 1_000_000e6);
-        usdc.mint(maker7Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 30_000e6);
-        _stakeWithAddr(maker5Addr, 30_000e6);
-        _stakeWithAddr(maker6Addr, 25_000e6);
-        _stakeWithAddr(maker7Addr, 25_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // totalActive = 50k+50k+50k+30k+30k+25k+25k = 260k
-        // eligible = 260k - 50k(maker1) - 50k(maker2) = 160k
-        // quorum = 30% of 160k = 48k
-
-        // maker4 (30k) + maker5 (30k) vote valid → 60k valid, 0 invalid
-        // total=60k, quorum: 60k*10000=600M >= 160k*3000=480M → quorum MET
-        // majority: valid 60k*2=120k > 60k total → strict majority → RESOLVES
-        // That's too easy. We need to prevent majority during resolveDispute.
-        // Single-side calls always produce 100% on that side → always majority.
-        //
-        // Key insight: the ONLY way to get quorum-met but no majority on expiry
-        // is if votes come from BOTH sides across separate calls, and neither
-        // achieves strict majority after either call.
-        //
-        // Call 1: maker4 (30k) votes invalid. total=30k < 48k quorum → returns.
-        // Call 2: maker5 (30k) + maker6 (25k) vote valid → valid=55k, invalid=30k, total=85k.
-        //   quorum: 85k*10000 >= 160k*3000 → 850M >= 480M ✓
-        //   valid majority: 55k*2=110k > 85k ✓ → RESOLVES. Still too easy.
-        //
-        // The problem: once quorum is met, the side that submitted votes last
-        // always has their votes counted fresh, and if they outnumber the other
-        // side total, they get majority. To NOT get majority, we need valid ≈ invalid ≈ 50%.
-        //
-        // Call 1: maker6 (25k) + maker7 (25k) vote invalid → invalid=50k, valid=0, total=50k
-        //   quorum: 50k*10000 >= 160k*3000 → 500M >= 480M ✓
-        //   invalid majority: 50k*2=100k > 50k ✓ → RESOLVES. Doh.
-        //
-        // Fundamental: with single-side per call, if quorum is met, the only side
-        // with votes has 100% → always majority. To avoid this, both sides need
-        // non-zero votes AND quorum met, which requires at least 2 calls, and
-        // the second call must not push its side to majority.
-        //
-        // Call 1: maker4 (30k) invalid. total=30k, quorum NOT met (30k < 48k). Returns.
-        // Call 2: maker5 (30k) valid. valid=30k, invalid=30k, total=60k.
-        //   quorum: 60k*10000 >= 160k*3000 → 600M >= 480M ✓
-        //   valid majority: 30k*2=60k > 60k → false (NOT strict)
-        //   invalid majority: 30k*2=60k > 60k → false
-        //   Neither side has majority → returns silently.
-        // Deadline expires → finalizeExpiredDispute → quorum met, plurality: 30k == 30k → tie.
-        // Code: `validWins = validWeight >= invalidWeight` → true → valid wins the tie.
-
-        // Call 1: maker4 votes invalid (30k)
-        {
-            bytes memory sig4 = _signAttestation(
-                maker4Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig4;
-            disputes.resolveDispute(intentId, false, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Call 2: maker5 votes valid (30k) — quorum met, but 50-50 → no majority
-        {
-            bytes memory sig5 = _signAttestation(
-                maker5Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig5;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId).resolved); // Still not resolved (no majority)
-
-        // Warp past deadline → finalize with plurality
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-        disputes.finalizeExpiredDispute(intentId);
-
-        // Tie: validWeight == invalidWeight → valid wins (>= check)
-        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
-        assertTrue(disp.resolved);
-        assertTrue(disp.fillDeemedValid);
-    }
-
-    // ═══════════════════════════════════════════
-    //  Phase A: Edge case & fuzz tests
-    // ═══════════════════════════════════════════
-
-    // --- calculateSlashAmount edge cases ---
-
-    function test_calculateSlashAmount_zeroFill() public view {
-        // Guard against division by zero
-        assertEq(disputes.calculateSlashAmount(0, 100_000e6), 0);
-    }
-
-    function test_calculateSlashAmount_zeroStake() public view {
-        // Fill of 10k, maker has 0 stake → capped at 0
-        assertEq(disputes.calculateSlashAmount(10_000e6, 0), 0);
-    }
-
-    function test_calculateSlashAmount_fillOf1() public view {
-        // Extremely small fill: multiplier = 2 + 650e6 = huge, capped at 15
-        // slash = 1 * 15 = 15 (tiny)
-        assertEq(disputes.calculateSlashAmount(1, 100_000e6), 15);
-    }
-
-    // --- Fuzz: slash curve ---
-
-    function testFuzz_calculateSlashAmount_bounded(uint256 fillAmount, uint256 makerStake) public view {
-        fillAmount = bound(fillAmount, 1, 1_000_000e6); // 1 wei to 1M USDC
-        makerStake = bound(makerStake, 0, 10_000_000e6);
-
-        uint256 slash = disputes.calculateSlashAmount(fillAmount, makerStake);
-
-        // Invariant 1: slash <= makerStake
-        assertLe(slash, makerStake);
-
-        // Invariant 2: slash <= fillAmount * maxMultiplier
-        uint256 maxSlash = fillAmount * disputes.slashMaxMultiplier();
-        if (maxSlash / disputes.slashMaxMultiplier() == fillAmount) {
-            // No overflow in max calculation
-            assertLe(slash, maxSlash);
-        }
-
-        // Invariant 3: slash >= fillAmount * baseMultiplier (unless capped by stake)
-        // multiplier >= base, so slash >= fillAmount * base unless capped
-        uint256 baseSlash = fillAmount * disputes.slashBaseMultiplier();
-        if (baseSlash / disputes.slashBaseMultiplier() == fillAmount) {
-            if (baseSlash <= makerStake) {
-                assertGe(slash, baseSlash);
-            }
-        }
-    }
-
-    // --- Accumulative voting across multiple calls ---
-
-    function test_accumulativeVoting_acrossTwoCalls() public {
-        uint256 maker4Key = 0xD00D;
-        uint256 maker5Key = 0xBAAD;
-        address maker4Addr = vm.addr(maker4Key);
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 30_000e6);
-        _stakeWithAddr(maker5Addr, 20_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // eligible = (150k+30k+20k) - 50k(maker1) - 50k(maker2) = 100k
-        // quorum = 30% of 100k = 30k
-
-        // Call 1: maker4 (30k valid). total=30k >= 30k quorum ✓
-        // majority: 30k*2=60k > 30k → strict majority → resolves immediately
-        // Hmm, that resolves. We need calls where quorum isn't met on first call.
-
-        // Set quorum to 60% so first call doesn't hit it
-        vm.prank(owner);
-        disputes.setQuorumParams(6000);
-        // quorum = 60% of 100k = 60k
-
-        // Call 1: maker4 (30k valid). total=30k < 60k quorum → returns, votes recorded
-        {
-            bytes memory sig = _signAttestation(
-                maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Verify votes were recorded
-        address[] memory attestors = disputes.getDisputeAttestors(intentId, true);
-        assertEq(attestors.length, 1);
-        assertEq(attestors[0], maker4Addr);
-
-        // Call 2: maker3 (50k valid) + maker5 (20k valid). total=30k+50k+20k=100k >= 60k ✓
-        // majority: 100k*2=200k > 100k → resolves
-        {
-            bytes memory sig3 = _signAttestation(
-                maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes memory sig5 = _signAttestation(
-                maker5Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](2);
-            sigs[0] = sig3;
-            sigs[1] = sig5;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-
-        assertTrue(disputes.getDispute(intentId).resolved);
-        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
-
-        // Verify all 3 attestors recorded
-        attestors = disputes.getDisputeAttestors(intentId, true);
-        assertEq(attestors.length, 3);
-    }
-
-    function test_accumulativeVoting_crossCallDuplicateReverts() public {
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Set high quorum so first call doesn't resolve
-        vm.prank(owner);
-        disputes.setQuorumParams(9000);
-
-        // Call 1: maker4 votes
-        bytes memory sig = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Call 2: maker4 tries again — reverts
-        vm.expectRevert("GauloiDisputes: already attested");
-        disputes.resolveDispute(intentId, true, sigs);
-    }
-
-    // --- Quorum boundary conditions ---
-
-    function test_quorumExactlyAtThreshold() public {
-        // Set up so participating is exactly 30% of eligible
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        // We need maker4's stake to be exactly 30% of eligible
-        // eligible = totalActive - maker1 - maker2
-        // If maker4 stakes 15k: totalActive = 150k+15k = 165k, eligible = 165k-50k-50k = 65k
-        // quorum = 30% of 65k = 19.5k → 15k < 19.5k → NOT met
-        // If maker4 stakes 30k: totalActive = 180k, eligible = 80k, quorum = 24k → 30k >= 24k ✓
-
-        // Use precise amounts: eligible = 100k, quorum = 30k exactly
-        // Need totalActive - 100k = maker1 + maker2 → current total = 150k, eligible = 50k
-        // Add maker4 with 50k → total = 200k, eligible = 100k, quorum = 30k
-        _stakeWithAddr(maker4Addr, 50_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // eligible = 200k - 50k - 50k = 100k, quorum = 30k
-        // maker4 (50k) votes → 50k >= 30k ✓, majority: 50k*2=100k > 50k ✓
-        // That resolves. Let's test the exact boundary differently.
-
-        // Use a maker with exactly 30k stake:
-        uint256 maker5Key = 0xBAAD;
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker5Addr, 30_000e6);
-
-        // New intent so dispute state is fresh
-        (bytes32 intentId2, DataTypes.Order memory order2) = _createAndFillIntent(5_000e6);
-        DataTypes.Commitment memory commitment2 = escrow.getCommitment(intentId2);
-
-        vm.startPrank(maker2Addr);
-        disputes.dispute(order2);
-        vm.stopPrank();
-
-        // eligible = 230k - 50k(maker1) - 50k(maker2) = 130k
-        // quorum = 30% of 130k = 39k
-
-        // maker5 (30k) votes → 30k < 39k → quorum NOT met → returns
-        {
-            bytes memory sig5 = _signAttestation(
-                maker5Key, intentId2, true, commitment2.fillTxHash, order2.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig5;
-            disputes.resolveDispute(intentId2, true, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId2).resolved);
-
-        // maker4 (50k) votes → total = 80k >= 39k ✓, majority: 80k*2 > 80k ✓
-        {
-            bytes memory sig4 = _signAttestation(
-                maker4Key, intentId2, true, commitment2.fillTxHash, order2.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig4;
-            disputes.resolveDispute(intentId2, true, sigs);
-        }
-        assertTrue(disputes.getDispute(intentId2).resolved);
-    }
-
-    function test_majorityExactly5050_noResolution() public {
-        // 50-50 split: neither side has strict majority (need >50%, not >=50%)
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 50_000e6); // Same as maker3
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // eligible = 200k - 50k - 50k = 100k, quorum = 30k
-
-        // maker4 votes invalid (50k). Quorum 50k >= 30k ✓
-        // BUT: only invalid side → 50k*2=100k > 50k → strict majority → resolves
-        // Can't get 50-50 from a single call. Need to set up carefully.
-
-        // Set quorum to 80% so neither single call meets quorum
-        vm.prank(owner);
-        disputes.setQuorumParams(8000);
-        // quorum = 80% of 100k = 80k
-
-        // Call 1: maker3 votes valid (50k). total=50k < 80k → returns
-        {
-            bytes memory sig3 = _signAttestation(
-                maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig3;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Call 2: maker4 votes invalid (50k). total=100k >= 80k ✓
-        // valid=50k, invalid=50k. Neither has majority (50k*2=100k NOT > 100k)
-        {
-            bytes memory sig4 = _signAttestation(
-                maker4Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-            );
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig4;
-            disputes.resolveDispute(intentId, false, sigs);
-        }
-        // Still not resolved — 50-50 split, no strict majority
-        assertFalse(disputes.getDispute(intentId).resolved);
-    }
-
-    // --- Zero eligible stake ---
-
-    function test_zeroEligibleStake_noResolution() public {
-        // Only 2 makers: maker1 (disputed) and maker2 (challenger). No one else to vote.
-        // Deploy fresh with only 2 makers
-        GauloiStaking freshStaking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
-        GauloiEscrow freshEscrow = new GauloiEscrow(address(freshStaking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
-        GauloiDisputes freshDisputes = new GauloiDisputes(
-            address(freshStaking), address(freshEscrow), address(usdc),
-            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, owner
-        );
-        vm.startPrank(owner);
-        freshStaking.setEscrow(address(freshEscrow));
-        freshStaking.setDisputes(address(freshDisputes));
-        freshEscrow.setDisputes(address(freshDisputes));
-        freshEscrow.addSupportedToken(address(usdc));
-        vm.stopPrank();
-
-        // Stake 2 makers
-        vm.startPrank(maker1Addr);
-        usdc.approve(address(freshStaking), 50_000e6);
-        freshStaking.stake(50_000e6);
-        vm.stopPrank();
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(freshStaking), 50_000e6);
-        freshStaking.stake(50_000e6);
-        vm.stopPrank();
-
-        // Execute order (need taker approval for fresh escrow)
-        vm.prank(taker);
-        usdc.approve(address(freshEscrow), type(uint256).max);
-
+    function test_resolve_revertsIfNoResolverForCorridor() public {
+        // Order to a corridor with no resolver configured
         DataTypes.Order memory order = DataTypes.Order({
             taker: taker,
             inputToken: address(usdc),
             inputAmount: 10_000e6,
             outputToken: address(usdc),
             minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
+            destinationChainId: 999_999, // unconfigured corridor
             destinationAddress: DEST_ADDRESS,
             expiry: block.timestamp + 1 hours,
-            nonce: 999
+            nonce: _testNonce++
         });
-
-        // Sign with fresh escrow's domain separator
-        bytes32 structHash = keccak256(abi.encode(
-            IntentLib.ORDER_TYPEHASH,
-            order.taker, order.inputToken, order.inputAmount,
-            order.outputToken, order.minOutputAmount,
-            order.destinationChainId, order.destinationAddress,
-            order.expiry, order.nonce
-        ));
-        bytes32 digest = MessageHashUtils.toTypedDataHash(freshEscrow.domainSeparator(), structHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(takerKey, digest);
-        bytes memory sig = abi.encodePacked(r, s, v);
-
-        vm.prank(maker1Addr);
-        bytes32 intentId = freshEscrow.executeOrder(order, sig);
-        vm.prank(maker1Addr);
-        freshEscrow.submitFill(intentId, keccak256("dest_tx"));
-
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(freshDisputes), type(uint256).max);
-        freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        // eligible = totalActive(100k) - maker1(50k) - maker2(50k) = 0
-        // No one can vote. Warp past deadline.
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-
-        // finalizeExpiredDispute: totalParticipating = 0 → default valid
-        freshDisputes.finalizeExpiredDispute(intentId);
-        assertTrue(freshDisputes.getDispute(intentId).resolved);
-        assertTrue(freshDisputes.getDispute(intentId).fillDeemedValid);
-    }
-
-    // --- Rounding/dust with multiple attestors ---
-
-    function test_attestorRewards_dustStaysInTreasury() public {
-        // Use 3 attestors with stakes that produce rounding dust
-        uint256 maker4Key = 0xD00D;
-        uint256 maker5Key = 0xBAAD;
-        address maker4Addr = vm.addr(maker4Key);
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 33_333e6);
-        _stakeWithAddr(maker5Addr, 33_333e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 disputesBefore = usdc.balanceOf(address(disputes));
-
-        // 3 attestors: maker3(50k), maker4(33,333), maker5(33,333) all vote valid
-        {
-            bytes memory sig3 = _signAttestation(maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-            bytes memory sig4 = _signAttestation(maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-            bytes memory sig5 = _signAttestation(maker5Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-            bytes[] memory sigs = new bytes[](3);
-            sigs[0] = sig3;
-            sigs[1] = sig4;
-            sigs[2] = sig5;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
-
-        // Bond = 250e6 (min). attestorPool = 250e6 / 4 = 62e6 (with 2e6 dust from bond split)
-        // totalWeight = 50_000e6 + 33_333e6 + 33_333e6 = 116_666e6
-        // maker3 share = 62e6 * 50_000e6 / 116_666e6 = 26_571_... → 26_571 (truncated)
-        // maker4 share = 62e6 * 33_333e6 / 116_666e6 = 17_714_... → 17_714 (truncated)
-        // maker5 share = same as maker4 = 17_714
-        // Total distributed = 26_571 + 17_714 + 17_714 = 61_999 < 62e6
-        // Dust: 62e6 - 61_999 = 1 stays in contract
-
-        // The contract should have: bond(250e6) - maker reward(125e6) - attestor distributed(≤62e6) + dust
-        // = treasury portion. Just verify contract balance is positive (dust retained).
-        uint256 disputesAfter = usdc.balanceOf(address(disputes));
-        // Treasury should have gotten: 250e6 - 125e6(maker) - ≤62e6(attestors) = ≥63e6
-        assertTrue(disputesAfter > 0);
-    }
-
-    // --- submitFill and reclaimExpired work when paused ---
-
-    function test_submitFill_worksWhenPaused() public {
-        (bytes32 intentId,) = _createAndFillIntent(10_000e6);
-        // Already filled in _createAndFillIntent, so let's test differently:
-        // Create a new order, execute, then pause, then submitFill
-
-        DataTypes.Order memory order2 = _makeOrder(5_000e6, 4_990e6);
-        bytes memory sig = _signOrder(takerKey, order2);
-        vm.prank(maker1Addr);
-        bytes32 intentId2 = escrow.executeOrder(order2, sig);
-
-        // Pause
-        vm.prank(address(disputes));
-        escrow.pause();
-
-        // submitFill should still work (not gated by whenNotPaused)
-        vm.prank(maker1Addr);
-        escrow.submitFill(intentId2, keccak256("fill_after_pause"));
-        assertTrue(escrow.getCommitment(intentId2).state == DataTypes.IntentState.Filled);
-    }
-
-    function test_reclaimExpired_worksWhenPaused() public {
-        DataTypes.Order memory order = _makeOrder(5_000e6, 4_990e6);
         bytes memory sig = _signOrder(takerKey, order);
         vm.prank(maker1Addr);
-        escrow.executeOrder(order, sig);
-
-        // Pause
-        vm.prank(address(disputes));
-        escrow.pause();
-
-        // Warp past commitment timeout
-        vm.warp(block.timestamp + COMMITMENT_TIMEOUT + 1);
-
-        // reclaimExpired should still work
-        vm.prank(taker);
-        escrow.reclaimExpired(order);
-    }
-
-    // --- slashPartial with pending unstake, maker stays active ---
-
-    function test_slashPartial_pendingUnstake_staysActive() public {
-        // maker1 stakes 50k, requests unstake 10k, then gets partially slashed
-        // but remains above minStake → stays active, unstake still pending
-        uint256 maker5Key = 0xBAAD;
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker5Addr, 50_000e6);
-
-        vm.prank(maker5Addr);
-        staking.requestUnstake(10_000e6);
-
-        // Create and dispute an intent with maker5
-        DataTypes.Order memory order = _makeOrder(1_000e6, 990e6);
-        bytes memory orderSig = _signOrder(takerKey, order);
-        vm.prank(maker5Addr);
-        bytes32 intentId = escrow.executeOrder(order, orderSig);
-        vm.prank(maker5Addr);
-        escrow.submitFill(intentId, keccak256("fill"));
-
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-        disputes.resolveDispute(intentId, false, sigs);
-
-        // $1k fill → slash 2,650. Remaining = 47,350 > 10k → stays active
-        DataTypes.MakerInfo memory info = staking.getMakerInfo(maker5Addr);
-        assertTrue(info.isActive);
-        assertEq(info.stakedAmount, 50_000e6 - 2_650e6);
-        // Unstake request should still be pending (maker stayed active)
-        assertGt(info.unstakeRequestTime, 0);
-        assertEq(info.unstakeAmount, 10_000e6);
-    }
-
-    // --- Fuzz: totalActiveStake invariant ---
-
-    function testFuzz_totalActiveStake_invariant(
-        uint256 stake1,
-        uint256 stake2,
-        uint256 slashAmt
-    ) public {
-        stake1 = bound(stake1, MIN_STAKE, 500_000e6);
-        stake2 = bound(stake2, MIN_STAKE, 500_000e6);
-        slashAmt = bound(slashAmt, 1, stake1);
-
-        // Use fresh addresses to avoid interference from setUp's existing stakes
-        address fuzzMaker1 = makeAddr("fuzzMaker1");
-        address fuzzMaker2 = makeAddr("fuzzMaker2");
-        usdc.mint(fuzzMaker1, stake1);
-        usdc.mint(fuzzMaker2, stake2);
-
-        uint256 baseTotalActive = staking.totalActiveStake(); // 150k from setUp
-
-        _stakeWithAddr(fuzzMaker1, stake1);
-        _stakeWithAddr(fuzzMaker2, stake2);
-
-        assertEq(staking.totalActiveStake(), baseTotalActive + stake1 + stake2);
-
-        // Partial slash fuzzMaker1
-        vm.prank(address(disputes));
-        uint256 slashed = staking.slashPartial(fuzzMaker1, keccak256("intent"), slashAmt);
-
-        uint256 remaining1 = stake1 - slashed;
-        uint256 expectedDelta;
-        if (remaining1 >= MIN_STAKE) {
-            expectedDelta = stake1 + stake2 - slashed;
-        } else {
-            expectedDelta = stake2; // fuzzMaker1 deactivated, only fuzzMaker2 contributes
-        }
-        assertEq(staking.totalActiveStake(), baseTotalActive + expectedDelta);
-
-        // Verify sum of fuzz maker active stakes
-        uint256 actualSum = 0;
-        if (staking.isActiveMaker(fuzzMaker1)) actualSum += staking.getStake(fuzzMaker1);
-        if (staking.isActiveMaker(fuzzMaker2)) actualSum += staking.getStake(fuzzMaker2);
-        assertEq(actualSum, expectedDelta);
-    }
-
-    // --- Fuzz: bond calculation ---
-
-    function testFuzz_calculateDisputeBond(uint256 fillAmount) public view {
-        fillAmount = bound(fillAmount, 0, 100_000_000e6); // 0 to 100M USDC
-
-        uint256 bond = disputes.calculateDisputeBond(fillAmount);
-
-        // Invariant: bond >= minDisputeBond
-        assertGe(bond, disputes.minDisputeBond());
-
-        // Invariant: bond >= fillAmount * bps / 10_000 (when no overflow)
-        uint256 bpsBond = (fillAmount * disputes.disputeBondBps()) / 10_000;
-        if (bpsBond > disputes.minDisputeBond()) {
-            assertEq(bond, bpsBond);
-        } else {
-            assertEq(bond, disputes.minDisputeBond());
-        }
-    }
-
-    // --- Exposure desync after partial slash ---
-
-    function test_resolveAsInvalid_multipleOutstandingFills_exposureCorrect() public {
-        // maker1 (50k) fills 4 intents of 10k each → 40k exposure
-        (bytes32 id1, DataTypes.Order memory order1) = _createAndFillIntent(10_000e6);
-        (bytes32 id2, DataTypes.Order memory order2) = _createAndFillIntent(10_000e6);
-        (bytes32 id3, DataTypes.Order memory order3) = _createAndFillIntent(10_000e6);
-        (bytes32 id4, DataTypes.Order memory order4) = _createAndFillIntent(10_000e6);
-
-        assertEq(staking.getExposure(maker1Addr), 40_000e6);
-
-        // Dispute fill #1 and resolve as invalid
-        DataTypes.Commitment memory commitment = escrow.getCommitment(id1);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order1);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, id1, false, commitment.fillTxHash, order1.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-        disputes.resolveDispute(id1, false, sigs);
-
-        // Slash: 10k fill, 50k stake. multiplier = 2 + 650e6/10_000e6 = 2.065
-        // slash = 10k * 2.065 = 20,650. Remaining stake = 29,350.
-        assertEq(staking.getStake(maker1Addr), 50_000e6 - 20_650e6);
-
-        // slashPartial caps exposure: min(40k, 29,350) = 29,350
-        // exposureBefore = 40k, exposureAfter = 29,350
-        // alreadyReduced = 40k - 29,350 = 10,650
-        // 10k (fillAmount) < 10,650 (alreadyReduced) → skip decreaseExposure
-        // Final exposure = 29,350
-        //
-        // Without the fix: exposure = 29,350 - 10,000 = 19,350 (WRONG — 3 fills outstanding = 30k)
-        // With the fix: exposure = 29,350 (correct — capped at remaining stake)
-        assertEq(staking.getExposure(maker1Addr), 29_350e6);
-
-        // Verify this is NOT 19,350 (the buggy value)
-        assertTrue(staking.getExposure(maker1Addr) != 19_350e6);
-    }
-
-    function test_resolveAsInvalid_singleFill_exposureZero() public {
-        // Single fill: after slash, no cap needed → normal decreaseExposure
-        (bytes32 id1, DataTypes.Order memory order1) = _createAndFillIntent(10_000e6);
-
-        assertEq(staking.getExposure(maker1Addr), 10_000e6);
-
-        DataTypes.Commitment memory commitment = escrow.getCommitment(id1);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order1);
-        vm.stopPrank();
-
-        bytes memory sig = _signAttestation(
-            maker3Key, id1, false, commitment.fillTxHash, order1.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig;
-        disputes.resolveDispute(id1, false, sigs);
-
-        // Slash 20,650. Remaining = 29,350. Exposure was 10k < 29,350 → no cap.
-        // alreadyReduced = 0, full decreaseExposure(10k) → exposure = 0
-        assertEq(staking.getExposure(maker1Addr), 0);
-    }
-
-    function test_getExposure_viewFunction() public {
-        assertEq(staking.getExposure(maker1Addr), 0);
-
-        _createAndFillIntent(10_000e6);
-        assertEq(staking.getExposure(maker1Addr), 10_000e6);
-
-        _createAndFillIntent(5_000e6);
-        assertEq(staking.getExposure(maker1Addr), 15_000e6);
-    }
-
-    // --- Attestor DoS protection (blacklisted attestor) ---
-
-    // Helper: deploy fresh system with blacklistable token
-    struct BlacklistTestEnv {
-        MockBlacklistableERC20 bToken;
-        GauloiStaking freshStaking;
-        GauloiEscrow freshEscrow;
-        GauloiDisputes freshDisputes;
-    }
-
-    function _deployBlacklistEnv() internal returns (BlacklistTestEnv memory env) {
-        env.bToken = new MockBlacklistableERC20("Bond USDC", "BUSDC", 6);
-        env.freshStaking = new GauloiStaking(address(env.bToken), MIN_STAKE, COOLDOWN, 1 hours, owner);
-        env.freshEscrow = new GauloiEscrow(address(env.freshStaking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
-        env.freshDisputes = new GauloiDisputes(
-            address(env.freshStaking), address(env.freshEscrow), address(env.bToken),
-            RESOLUTION_WINDOW, BOND_BPS, MIN_BOND, owner
-        );
-
-        vm.startPrank(owner);
-        env.freshStaking.setEscrow(address(env.freshEscrow));
-        env.freshStaking.setDisputes(address(env.freshDisputes));
-        env.freshEscrow.setDisputes(address(env.freshDisputes));
-        env.freshEscrow.addSupportedToken(address(env.bToken));
-        vm.stopPrank();
-    }
-
-    function _fundAndStake(BlacklistTestEnv memory env, address maker, uint256 amount) internal {
-        env.bToken.mint(maker, 1_000_000e6);
-        vm.startPrank(maker);
-        env.bToken.approve(address(env.freshStaking), amount);
-        env.freshStaking.stake(amount);
-        vm.stopPrank();
-    }
-
-    function _signOrderForEscrow(GauloiEscrow targetEscrow, DataTypes.Order memory order) internal view returns (bytes memory) {
-        bytes32 structHash = keccak256(abi.encode(
-            IntentLib.ORDER_TYPEHASH,
-            order.taker, order.inputToken, order.inputAmount,
-            order.outputToken, order.minOutputAmount,
-            order.destinationChainId, order.destinationAddress,
-            order.expiry, order.nonce
-        ));
-        bytes32 digest = MessageHashUtils.toTypedDataHash(targetEscrow.domainSeparator(), structHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(takerKey, digest);
-        return abi.encodePacked(r, s, v);
-    }
-
-    function _signAttestationForDisputes(
-        GauloiDisputes targetDisputes,
-        uint256 privateKey,
-        bytes32 intentId,
-        bool fillValid,
-        bytes32 fillTxHash,
-        uint256 destChainId
-    ) internal view returns (bytes memory) {
-        bytes32 structHash = SignatureLib.hashAttestation(intentId, fillValid, fillTxHash, destChainId);
-        bytes32 digest = MessageHashUtils.toTypedDataHash(targetDisputes.domainSeparator(), structHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
-        return abi.encodePacked(r, s, v);
-    }
-
-    function test_resolveDispute_blacklistedAttestor_stillResolves() public {
-        BlacklistTestEnv memory env = _deployBlacklistEnv();
-
-        _fundAndStake(env, maker1Addr, 50_000e6);
-        _fundAndStake(env, maker2Addr, 50_000e6);
-        _fundAndStake(env, maker3Addr, 50_000e6);
-        env.bToken.mint(taker, 1_000_000e6);
-        vm.prank(taker);
-        env.bToken.approve(address(env.freshEscrow), type(uint256).max);
-
-        // Create and fill intent
-        DataTypes.Order memory order = DataTypes.Order({
-            taker: taker,
-            inputToken: address(env.bToken),
-            inputAmount: 10_000e6,
-            outputToken: address(env.bToken),
-            minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
-            destinationAddress: DEST_ADDRESS,
-            expiry: block.timestamp + 1 hours,
-            nonce: 8888
-        });
-
-        bytes memory orderSig = _signOrderForEscrow(env.freshEscrow, order);
+        bytes32 intentId = escrow.executeOrder(order, sig);
         vm.prank(maker1Addr);
-        bytes32 intentId = env.freshEscrow.executeOrder(order, orderSig);
-        vm.prank(maker1Addr);
-        env.freshEscrow.submitFill(intentId, keccak256("dest_tx"));
+        escrow.submitFill(intentId, keccak256("tx"));
 
-        DataTypes.Commitment memory commitment = env.freshEscrow.getCommitment(intentId);
+        _challengeAs(challenger, order);
 
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        env.bToken.approve(address(env.freshDisputes), type(uint256).max);
-        env.freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker3BalBefore = env.bToken.balanceOf(maker3Addr);
-
-        // BLACKLIST maker3 before resolution
-        env.bToken.blacklist(maker3Addr);
-
-        // maker3 attests fill-valid
-        bytes memory attSig = _signAttestationForDisputes(
-            env.freshDisputes, maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attSig;
-
-        // This MUST NOT revert despite maker3 being blacklisted
-        env.freshDisputes.resolveDispute(intentId, true, sigs);
-
-        // Verify dispute resolved
-        assertTrue(env.freshDisputes.getDispute(intentId).resolved);
-        assertTrue(env.freshDisputes.getDispute(intentId).fillDeemedValid);
-
-        // maker3 balance unchanged (transfer to blacklisted address failed)
-        assertEq(env.bToken.balanceOf(maker3Addr), maker3BalBefore);
-
-        // The failed share stays in the disputes contract (treasury)
-        assertGt(env.bToken.balanceOf(address(env.freshDisputes)), 0);
+        vm.expectRevert("GauloiDisputes: no resolver for corridor");
+        disputes.resolve(intentId, "");
     }
 
-    function test_resolveDispute_blacklistedAttestor_otherAttestorsGetRewards() public {
-        BlacklistTestEnv memory env = _deployBlacklistEnv();
-
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-
-        _fundAndStake(env, maker1Addr, 50_000e6);
-        _fundAndStake(env, maker2Addr, 50_000e6);
-        _fundAndStake(env, maker3Addr, 50_000e6);
-        _fundAndStake(env, maker4Addr, 50_000e6);
-        env.bToken.mint(taker, 1_000_000e6);
-        vm.prank(taker);
-        env.bToken.approve(address(env.freshEscrow), type(uint256).max);
-
-        DataTypes.Order memory order = DataTypes.Order({
-            taker: taker,
-            inputToken: address(env.bToken),
-            inputAmount: 10_000e6,
-            outputToken: address(env.bToken),
-            minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
-            destinationAddress: DEST_ADDRESS,
-            expiry: block.timestamp + 1 hours,
-            nonce: 9999
-        });
-
-        bytes memory orderSig = _signOrderForEscrow(env.freshEscrow, order);
-        vm.prank(maker1Addr);
-        bytes32 intentId = env.freshEscrow.executeOrder(order, orderSig);
-        vm.prank(maker1Addr);
-        env.freshEscrow.submitFill(intentId, keccak256("dest_tx"));
-
-        DataTypes.Commitment memory commitment = env.freshEscrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        env.bToken.approve(address(env.freshDisputes), type(uint256).max);
-        env.freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        // Blacklist maker3 BEFORE resolution
-        env.bToken.blacklist(maker3Addr);
-
-        uint256 maker4BalBefore = env.bToken.balanceOf(maker4Addr);
-
-        // Both maker3 (blacklisted) and maker4 (normal) attest fill-valid
-        bytes memory sig3 = _signAttestationForDisputes(
-            env.freshDisputes, maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes memory sig4 = _signAttestationForDisputes(
-            env.freshDisputes, maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](2);
-        sigs[0] = sig3;
-        sigs[1] = sig4;
-
-        env.freshDisputes.resolveDispute(intentId, true, sigs);
-        assertTrue(env.freshDisputes.getDispute(intentId).resolved);
-
-        // maker4 received their pro-rata share
-        // Bond = 250e6. attestorPool = 250e6/4 = 62,500,000.
-        // totalWeight = 50k + 50k = 100k. maker4's share = 62,500,000 * 50k / 100k = 31,250,000.
-        assertEq(env.bToken.balanceOf(maker4Addr) - maker4BalBefore, 31_250_000);
-
-        // maker3's share (31,250,000) stayed in the contract
-        assertGe(env.bToken.balanceOf(address(env.freshDisputes)), 31_250_000);
-    }
-
-    // --- Maker/Challenger blacklist DoS protection ---
-
-    function test_resolveAsValid_blacklistedMaker_stillResolves() public {
-        BlacklistTestEnv memory env = _deployBlacklistEnv();
-
-        _fundAndStake(env, maker1Addr, 50_000e6);
-        _fundAndStake(env, maker2Addr, 50_000e6);
-        _fundAndStake(env, maker3Addr, 50_000e6);
-        env.bToken.mint(taker, 1_000_000e6);
-        vm.prank(taker);
-        env.bToken.approve(address(env.freshEscrow), type(uint256).max);
-
-        DataTypes.Order memory order = DataTypes.Order({
-            taker: taker,
-            inputToken: address(env.bToken),
-            inputAmount: 10_000e6,
-            outputToken: address(env.bToken),
-            minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
-            destinationAddress: DEST_ADDRESS,
-            expiry: block.timestamp + 1 hours,
-            nonce: 7770
-        });
-
-        bytes memory orderSig = _signOrderForEscrow(env.freshEscrow, order);
-        vm.prank(maker1Addr);
-        bytes32 intentId = env.freshEscrow.executeOrder(order, orderSig);
-        vm.prank(maker1Addr);
-        env.freshEscrow.submitFill(intentId, keccak256("dest_tx"));
-
-        DataTypes.Commitment memory commitment = env.freshEscrow.getCommitment(intentId);
-
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        env.bToken.approve(address(env.freshDisputes), type(uint256).max);
-        env.freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker1BalBefore = env.bToken.balanceOf(maker1Addr);
-
-        // BLACKLIST maker1 (the fill maker) before resolution
-        env.bToken.blacklist(maker1Addr);
-
-        // maker3 attests fill-valid → resolves as valid
-        bytes memory attSig = _signAttestationForDisputes(
-            env.freshDisputes, maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attSig;
-
-        // Must NOT revert despite maker1 being blacklisted
-        env.freshDisputes.resolveDispute(intentId, true, sigs);
-
-        // Dispute resolved successfully
-        assertTrue(env.freshDisputes.getDispute(intentId).resolved);
-        assertTrue(env.freshDisputes.getDispute(intentId).fillDeemedValid);
-
-        // maker1 balance unchanged (transfer to blacklisted address failed)
-        assertEq(env.bToken.balanceOf(maker1Addr), maker1BalBefore);
-
-        // The failed maker reward stays in disputes contract as treasury
-        // Bond = 250e6, makerReward = 250e6 / 2 = 125e6
-        assertGe(env.bToken.balanceOf(address(env.freshDisputes)), 125e6);
-
-        // Escrow-side: maker was also blacklisted for the settlement transfer,
-        // so escrowed taker funds (10,000e6) stay in escrow (recoverable via rescueTokens)
-        assertGe(env.bToken.balanceOf(address(env.freshEscrow)), 10_000e6);
-    }
-
-    function test_resolveAsInvalid_blacklistedChallenger_stillResolves() public {
-        BlacklistTestEnv memory env = _deployBlacklistEnv();
-
-        _fundAndStake(env, maker1Addr, 50_000e6);
-        _fundAndStake(env, maker2Addr, 50_000e6);
-        _fundAndStake(env, maker3Addr, 50_000e6);
-        env.bToken.mint(taker, 1_000_000e6);
-        vm.prank(taker);
-        env.bToken.approve(address(env.freshEscrow), type(uint256).max);
-
-        DataTypes.Order memory order = DataTypes.Order({
-            taker: taker,
-            inputToken: address(env.bToken),
-            inputAmount: 10_000e6,
-            outputToken: address(env.bToken),
-            minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
-            destinationAddress: DEST_ADDRESS,
-            expiry: block.timestamp + 1 hours,
-            nonce: 7771
-        });
-
-        bytes memory orderSig = _signOrderForEscrow(env.freshEscrow, order);
-        vm.prank(maker1Addr);
-        bytes32 intentId = env.freshEscrow.executeOrder(order, orderSig);
-        vm.prank(maker1Addr);
-        env.freshEscrow.submitFill(intentId, keccak256("dest_tx"));
-
-        DataTypes.Commitment memory commitment = env.freshEscrow.getCommitment(intentId);
-
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        env.bToken.approve(address(env.freshDisputes), type(uint256).max);
-        env.freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker2BalBefore = env.bToken.balanceOf(maker2Addr);
-
-        // BLACKLIST maker2 (the challenger) before resolution
-        env.bToken.blacklist(maker2Addr);
-
-        // maker3 attests fill-invalid → resolves as invalid
-        bytes memory attSig = _signAttestationForDisputes(
-            env.freshDisputes, maker3Key, intentId, false, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attSig;
-
-        // Must NOT revert despite maker2 (challenger) being blacklisted
-        env.freshDisputes.resolveDispute(intentId, false, sigs);
-
-        // Dispute resolved successfully
-        assertTrue(env.freshDisputes.getDispute(intentId).resolved);
-        assertFalse(env.freshDisputes.getDispute(intentId).fillDeemedValid);
-
-        // maker2 balance unchanged (transfer to blacklisted address failed)
-        assertEq(env.bToken.balanceOf(maker2Addr), maker2BalBefore);
-
-        // The challenger's bond + slash reward stays in disputes contract as treasury
-        assertGt(env.bToken.balanceOf(address(env.freshDisputes)), 0);
-
-        // Taker (not blacklisted) was still refunded via escrow.resolveInvalid
-        assertGe(env.bToken.balanceOf(taker), 10_000e6);
-    }
-
-    function test_resolveAsValid_nonBlacklistedMaker_getsReward() public {
-        BlacklistTestEnv memory env = _deployBlacklistEnv();
-
-        _fundAndStake(env, maker1Addr, 50_000e6);
-        _fundAndStake(env, maker2Addr, 50_000e6);
-        _fundAndStake(env, maker3Addr, 50_000e6);
-        env.bToken.mint(taker, 1_000_000e6);
-        vm.prank(taker);
-        env.bToken.approve(address(env.freshEscrow), type(uint256).max);
-
-        DataTypes.Order memory order = DataTypes.Order({
-            taker: taker,
-            inputToken: address(env.bToken),
-            inputAmount: 10_000e6,
-            outputToken: address(env.bToken),
-            minOutputAmount: 9_990e6,
-            destinationChainId: DEST_CHAIN_ID,
-            destinationAddress: DEST_ADDRESS,
-            expiry: block.timestamp + 1 hours,
-            nonce: 7772
-        });
-
-        bytes memory orderSig = _signOrderForEscrow(env.freshEscrow, order);
-        vm.prank(maker1Addr);
-        bytes32 intentId = env.freshEscrow.executeOrder(order, orderSig);
-        vm.prank(maker1Addr);
-        env.freshEscrow.submitFill(intentId, keccak256("dest_tx"));
-
-        DataTypes.Commitment memory commitment = env.freshEscrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        env.bToken.approve(address(env.freshDisputes), type(uint256).max);
-        env.freshDisputes.dispute(order);
-        vm.stopPrank();
-
-        uint256 maker1BalBefore = env.bToken.balanceOf(maker1Addr);
-
-        // maker3 attests fill-valid → resolves as valid, maker1 NOT blacklisted
-        bytes memory attSig = _signAttestationForDisputes(
-            env.freshDisputes, maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = attSig;
-
-        env.freshDisputes.resolveDispute(intentId, true, sigs);
-
-        assertTrue(env.freshDisputes.getDispute(intentId).resolved);
-
-        // maker1 received reward + escrowed funds: bond/2 = 125e6 + escrow = 10,000e6
-        assertEq(env.bToken.balanceOf(maker1Addr) - maker1BalBefore, 10_125e6);
-    }
-
-    // --- Eligible-stake underflow protection ---
-
-    function test_finalizeExpiredDispute_deactivatedMakerAndChallenger_noUnderflow() public {
-        // Reproduce: totalActiveStake < getStake(maker) + getStake(challenger)
-        // This caused underflow before the clamped subtraction fix.
-        //
-        // Setup: maker4 as attestor with small stake. All three main makers
-        // get slashed and deactivated, leaving only maker4 active.
-
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6); // Right at minStake
-
-        // Create and fill intent with maker1
+    function test_resolve_passesArgsToResolver() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Valid);
 
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
+        disputes.resolve(intentId, hex"deadbeef");
 
-        // Set quorum to 99% so votes get recorded but can't resolve
-        vm.prank(owner);
-        disputes.setQuorumParams(9900);
+        assertEq(resolver.lastIntentId(), intentId);
+        assertEq(resolver.lastEvidence(), hex"deadbeef");
+        assertEq(resolver.lastDestinationChainId(), DEST_CHAIN_ID);
+        assertEq(resolver.callCount(), 1);
+    }
 
-        // maker4 votes fill-valid (10k weight). Quorum not met (10k < 99% of eligible).
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig4;
-        disputes.resolveDispute(intentId, true, sigs);
-        assertFalse(disputes.getDispute(intentId).resolved);
+    // =========================================================================
+    // finalizeExpiredDispute() — maker must defend; silence convicts
+    // =========================================================================
 
-        // Slash all three main makers below minStake via separate disputes
-        // (simulated with direct slashPartial calls from disputes contract)
-        vm.startPrank(address(disputes));
-        staking.slashPartial(maker1Addr, keccak256("other1"), 42_000e6);
-        // maker1: 50k - 42k = 8k < 10k min → deactivated
-        staking.slashPartial(maker2Addr, keccak256("other2"), 42_000e6);
-        // maker2: 50k - 42k = 8k < 10k min → deactivated
-        staking.slashPartial(maker3Addr, keccak256("other3"), 42_000e6);
-        // maker3: 50k - 42k = 8k < 10k min → deactivated
-        vm.stopPrank();
+    function test_finalizeExpired_resolvesInvalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(20_000e6);
+        uint256 bond = disputes.calculateDisputeBond(20_000e6);
+        _challengeAs(challenger, order);
 
-        // Now: totalActiveStake = 10k (only maker4)
-        // getStake(maker1) = 8k, getStake(maker2) = 8k
-        // Without fix: eligible = 10k - 8k - 8k = -6k → UNDERFLOW REVERT
-        // With fix: eligible = max(10k - 16k, 0) = 0
-        assertEq(staking.totalActiveStake(), 10_000e6);
-        assertEq(staking.getStake(maker1Addr), 8_000e6);
-        assertEq(staking.getStake(maker2Addr), 8_000e6);
-
-        // Warp past deadline
         vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
 
-        // This MUST NOT revert. totalParticipating = 10k > 0, enters quorum check path.
-        // eligible = 0, quorum check: 10k*10000 >= 0*9900 → 100M >= 0 → quorum met.
-        // But eligible==0 is guarded: `eligible == 0 || ...` → quorumMet = false in the check.
-        // Actually: `eligible > 0 && totalParticipating * 10_000 >= eligible * quorumBps`
-        // eligible = 0 → false → quorumMet = false → quorum fail path.
+        uint256 takerBefore = usdc.balanceOf(taker);
+        uint256 challengerBefore = usdc.balanceOf(challenger);
+
+        vm.expectEmit(true, false, false, true);
+        emit IGauloiDisputes.DisputeResolved(intentId, false);
         disputes.finalizeExpiredDispute(intentId);
 
-        // Quorum failure incremented (not resolved)
-        assertEq(disputes.getQuorumFailCount(intentId), 1);
+        // Undefended challenge resolves against the maker
+        uint256 expectedSlash = 40_650e6;
+        assertEq(usdc.balanceOf(taker) - takerBefore, 20_000e6);
+        assertEq(usdc.balanceOf(challenger) - challengerBefore, bond + expectedSlash / 4);
+        assertEq(staking.getStake(maker1Addr), 50_000e6 - expectedSlash);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Expired);
     }
 
-    function test_resolveDispute_deactivatedMaker_noUnderflow() public {
-        // Same underflow scenario but through the resolveDispute path.
-        // With eligible clamped to 0, quorum can't be met → returns silently.
-
-        uint256 maker4Key = 0xD00D;
-        uint256 maker5Key = 0xBAAD;
-        address maker4Addr = vm.addr(maker4Key);
-        address maker5Addr = vm.addr(maker5Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        usdc.mint(maker5Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 10_000e6);
-        _stakeWithAddr(maker5Addr, 10_000e6);
-
+    function test_finalizeExpired_revertsBeforeDeadline() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        _challengeAs(challenger, order);
 
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Slash all main makers below minStake
-        vm.startPrank(address(disputes));
-        staking.slashPartial(maker1Addr, keccak256("o1"), 42_000e6);
-        staking.slashPartial(maker2Addr, keccak256("o2"), 42_000e6);
-        staking.slashPartial(maker3Addr, keccak256("o3"), 42_000e6);
-        vm.stopPrank();
-
-        // totalActive = 20k (maker4 + maker5). getStake(maker1) = 8k. getStake(maker2) = 8k.
-        // Without fix: eligible = 20k - 8k - 8k = 4k (OK here, but maker4+maker5 submit)
-        // Let's slash maker5 too to make totalActive = 10k
-        vm.prank(address(disputes));
-        staking.slashPartial(maker5Addr, keccak256("o5"), 2_000e6);
-        // maker5: 10k - 2k = 8k < 10k → deactivated. totalActive = 10k (only maker4).
-
-        // Without fix: eligible = 10k - 8k - 8k = UNDERFLOW
-        // With fix: eligible = 0
-
-        // maker4 submits attestation — this call should NOT revert
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](1);
-        sigs[0] = sig4;
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Not resolved (eligible=0 → quorum impossible)
-        assertFalse(disputes.getDispute(intentId).resolved);
+        vm.expectRevert("GauloiDisputes: deadline not passed");
+        disputes.finalizeExpiredDispute(intentId);
     }
 
-    function test_eligibleStake_normalPath_stillWorks() public {
-        // Sanity check: eligible-stake calculation still produces correct non-zero values
-        // when all makers are active (no deactivation, no underflow risk).
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 50_000e6);
-
+    function test_finalizeExpired_revertsIfResolved() public {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        _challengeAs(challenger, order);
+        resolver.setVerdict(IResolver.Verdict.Valid);
+        disputes.resolve(intentId, "");
 
-        // maker2 disputes
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // totalActive = 200k (50k * 4). eligible = 200k - 50k(maker1) - 50k(maker2) = 100k.
-        assertEq(staking.totalActiveStake(), 200_000e6);
-
-        // maker3 + maker4 vote fill-valid (100k weight = 100% of eligible → quorum met)
-        bytes memory sig3 = _signAttestation(
-            maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes memory sig4 = _signAttestation(
-            maker4Key, intentId, true, commitment.fillTxHash, order.destinationChainId
-        );
-        bytes[] memory sigs = new bytes[](2);
-        sigs[0] = sig3;
-        sigs[1] = sig4;
-        disputes.resolveDispute(intentId, true, sigs);
-
-        // Should resolve — quorum met with strict majority
-        assertTrue(disputes.getDispute(intentId).resolved);
-        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
+        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
+        vm.expectRevert("GauloiDisputes: already resolved");
+        disputes.finalizeExpiredDispute(intentId);
     }
 
-    // --- Expired dispute tie → valid wins ---
-
-    // --- Admin events ---
-
-    function test_setDisputeResolutionWindow_emitsEvent() public {
-        vm.prank(owner);
-        vm.expectEmit(false, false, false, true);
-        emit IGauloiDisputes.ResolutionWindowUpdated(RESOLUTION_WINDOW, 12 hours);
-        disputes.setDisputeResolutionWindow(12 hours);
+    function test_finalizeExpired_revertsIfNoDispute() public {
+        vm.expectRevert("GauloiDisputes: no dispute");
+        disputes.finalizeExpiredDispute(keccak256("nothing"));
     }
 
-    function test_setDisputeBondParams_emitsEvent() public {
-        vm.prank(owner);
-        vm.expectEmit(false, false, false, true);
-        emit IGauloiDisputes.BondParamsUpdated(500, 100e6);
-        disputes.setDisputeBondParams(500, 100e6);
+    // =========================================================================
+    // Slash curve
+    // =========================================================================
+
+    function test_calculateSlashAmount_curve() public view {
+        // Large fill: multiplier → base (2×). 100k fill → 2 + 650/100_000 = 2.0065×
+        assertEq(disputes.calculateSlashAmount(100_000e6, type(uint256).max), 200_650e6);
+
+        // Tiny fill: capped at 15×. 50 USDC fill → 2 + 13 = 15 (capped)
+        assertEq(disputes.calculateSlashAmount(50e6, type(uint256).max), 750e6);
+
+        // Capped at maker stake
+        assertEq(disputes.calculateSlashAmount(100_000e6, 50_000e6), 50_000e6);
+
+        // Zero fill → zero
+        assertEq(disputes.calculateSlashAmount(0, 50_000e6), 0);
     }
 
-    function test_setSlashCurveParams_emitsEvent() public {
+    // =========================================================================
+    // Admin
+    // =========================================================================
+
+    function test_setResolver() public {
+        address newResolver = makeAddr("newResolver");
+        vm.expectEmit(true, true, true, false);
+        emit IGauloiDisputes.ResolverUpdated(1, address(0), newResolver);
         vm.prank(owner);
-        vm.expectEmit(false, false, false, true);
-        emit IGauloiDisputes.SlashCurveUpdated(3, 800e6, 20);
-        disputes.setSlashCurveParams(3, 800e6, 20);
+        disputes.setResolver(1, newResolver);
+        assertEq(address(disputes.resolvers(1)), newResolver);
+
+        // Can be unset (corridor loses its arbiter → resolve reverts, finalize still works)
+        vm.prank(owner);
+        disputes.setResolver(1, address(0));
+        assertEq(address(disputes.resolvers(1)), address(0));
     }
 
-    function test_setQuorumParams_emitsEvent() public {
-        vm.prank(owner);
-        vm.expectEmit(false, false, false, true);
-        emit IGauloiDisputes.QuorumUpdated(3000, 5000);
-        disputes.setQuorumParams(5000);
+    function test_setResolver_onlyOwner() public {
+        vm.prank(challenger);
+        vm.expectRevert();
+        disputes.setResolver(1, address(resolver));
     }
 
-    // --- Bounds ---
-
-    function test_setDisputeResolutionWindow_tooShort_reverts() public {
+    function test_setTreasury() public {
+        address newTreasury = makeAddr("newTreasury");
         vm.prank(owner);
+        disputes.setTreasury(newTreasury);
+        assertEq(disputes.treasury(), newTreasury);
+
+        vm.prank(owner);
+        vm.expectRevert("GauloiDisputes: zero address");
+        disputes.setTreasury(address(0));
+
+        vm.prank(challenger);
+        vm.expectRevert();
+        disputes.setTreasury(newTreasury);
+    }
+
+    function test_setDisputeResolutionWindow_bounds() public {
+        vm.startPrank(owner);
         vm.expectRevert("GauloiDisputes: window out of range");
-        disputes.setDisputeResolutionWindow(59 minutes);
-    }
-
-    function test_setDisputeResolutionWindow_tooLong_reverts() public {
-        vm.prank(owner);
+        disputes.setDisputeResolutionWindow(30 minutes);
         vm.expectRevert("GauloiDisputes: window out of range");
         disputes.setDisputeResolutionWindow(31 days);
-    }
-
-    function test_setDisputeResolutionWindow_atBounds_succeeds() public {
-        vm.startPrank(owner);
-        disputes.setDisputeResolutionWindow(1 hours);
-        assertEq(disputes.disputeResolutionWindow(), 1 hours);
-        disputes.setDisputeResolutionWindow(30 days);
-        assertEq(disputes.disputeResolutionWindow(), 30 days);
+        disputes.setDisputeResolutionWindow(12 hours);
         vm.stopPrank();
+        assertEq(disputes.disputeResolutionWindow(), 12 hours);
     }
 
-    function test_setDisputeBondParams_bpsExceeds100_reverts() public {
+    function test_setDisputeBondParams() public {
+        vm.prank(owner);
+        disputes.setDisputeBondParams(100, 500e6);
+        assertEq(disputes.disputeBondBps(), 100);
+        assertEq(disputes.minDisputeBond(), 500e6);
+
         vm.prank(owner);
         vm.expectRevert("GauloiDisputes: bps exceeds 100%");
-        disputes.setDisputeBondParams(10_001, 1e6);
+        disputes.setDisputeBondParams(10_001, 500e6);
     }
 
-    function test_setDisputeBondParams_atMaxBps_succeeds() public {
-        vm.prank(owner);
-        disputes.setDisputeBondParams(10_000, 1e6);
-        assertEq(disputes.disputeBondBps(), 10_000);
-    }
-
-    function test_setSlashCurveParams_baseZero_reverts() public {
-        vm.prank(owner);
+    function test_setSlashCurveParams_bounds() public {
+        vm.startPrank(owner);
         vm.expectRevert("GauloiDisputes: invalid slash curve");
         disputes.setSlashCurveParams(0, 650e6, 15);
-    }
-
-    function test_setSlashCurveParams_maxLessThanBase_reverts() public {
-        vm.prank(owner);
         vm.expectRevert("GauloiDisputes: invalid slash curve");
-        disputes.setSlashCurveParams(10, 650e6, 5);
-    }
-
-    function test_setSlashCurveParams_maxAbove100_reverts() public {
-        vm.prank(owner);
+        disputes.setSlashCurveParams(3, 650e6, 2); // max < base
         vm.expectRevert("GauloiDisputes: invalid slash curve");
-        disputes.setSlashCurveParams(1, 650e6, 101);
+        disputes.setSlashCurveParams(2, 650e6, 101);
+        disputes.setSlashCurveParams(3, 500e6, 20);
+        vm.stopPrank();
+        assertEq(disputes.slashBaseMultiplier(), 3);
     }
 
-    function test_setSlashCurveParams_atBounds_succeeds() public {
-        vm.startPrank(owner);
-        disputes.setSlashCurveParams(1, 0, 1);
-        assertEq(disputes.slashBaseMultiplier(), 1);
-        assertEq(disputes.slashMaxMultiplier(), 1);
-        disputes.setSlashCurveParams(1, 650e6, 100);
-        assertEq(disputes.slashMaxMultiplier(), 100);
-        vm.stopPrank();
-    }
+    function test_withdrawTreasury() public {
+        usdc.mint(address(disputes), 1_000e6);
 
-    function test_expiredDispute_tieBreaksToValid() public {
-        // This is a focused test confirming that validWeight >= invalidWeight
-        // means valid wins ties.
-        uint256 maker4Key = 0xD00D;
-        address maker4Addr = vm.addr(maker4Key);
-        usdc.mint(maker4Addr, 1_000_000e6);
-        _stakeWithAddr(maker4Addr, 50_000e6);
-
-        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
-        DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
-
-        vm.startPrank(maker2Addr);
-        usdc.approve(address(disputes), type(uint256).max);
-        disputes.dispute(order);
-        vm.stopPrank();
-
-        // Set quorum high enough that single calls don't trigger quorum
         vm.prank(owner);
-        disputes.setQuorumParams(9000);
-        // eligible = 200k - 50k - 50k = 100k, quorum = 90k
+        disputes.withdrawTreasury(treasury, 1_000e6);
+        assertEq(usdc.balanceOf(treasury), 1_000e6);
 
-        // maker3 (50k) valid, maker4 (50k) invalid → total 100k >= 90k ✓
-        // But they submit in separate calls, each below quorum
+        vm.prank(challenger);
+        vm.expectRevert();
+        disputes.withdrawTreasury(challenger, 1);
+    }
 
-        // Call 1: maker3 valid (50k), quorum: 50k < 90k → returns
-        {
-            bytes memory sig3 = _signAttestation(maker3Key, intentId, true, commitment.fillTxHash, order.destinationChainId);
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig3;
-            disputes.resolveDispute(intentId, true, sigs);
-        }
+    function test_constructor_zeroAddressReverts() public {
+        vm.expectRevert("GauloiDisputes: zero address");
+        new GauloiDisputes(address(0), address(escrow), address(usdc), 24 hours, 200, 250e6, treasury, owner);
 
-        // Call 2: maker4 invalid (50k), total=100k >= 90k ✓
-        // valid=50k, invalid=50k. Neither strict majority (50k*2=100k NOT > 100k)
-        {
-            bytes memory sig4 = _signAttestation(maker4Key, intentId, false, commitment.fillTxHash, order.destinationChainId);
-            bytes[] memory sigs = new bytes[](1);
-            sigs[0] = sig4;
-            disputes.resolveDispute(intentId, false, sigs);
-        }
-        assertFalse(disputes.getDispute(intentId).resolved);
-
-        // Expire → plurality: 50k == 50k → valid wins (>= tie-break)
-        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
-        disputes.finalizeExpiredDispute(intentId);
-
-        assertTrue(disputes.getDispute(intentId).resolved);
-        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
+        vm.expectRevert("GauloiDisputes: zero address");
+        new GauloiDisputes(address(staking), address(escrow), address(usdc), 24 hours, 200, 250e6, address(0), owner);
     }
 }
 
-// Need these imports visible in this file for setUp
-import {MockERC20} from "../helpers/MockERC20.sol";
-import {MockBlacklistableERC20} from "../helpers/MockBlacklistableERC20.sol";
-import {GauloiStaking} from "../../src/GauloiStaking.sol";
-import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
+/// @dev Blacklist tolerance: resolution must complete even when a reward
+///      recipient is blacklisted by the bond token (funds stay in the contract,
+///      recoverable via withdrawTreasury)
+contract GauloiDisputesBlacklistTest is BaseTest {
+    GauloiDisputes public disputes;
+    MockResolver public resolver;
+    MockBlacklistableERC20 public busdc;
 
-contract MockERC20Harness is MockERC20 {
-    constructor(string memory name, string memory symbol, uint8 decimals_)
-        MockERC20(name, symbol, decimals_) {}
+    address public maker1Addr = makeAddr("blMaker1");
+    address public challenger = makeAddr("blChallenger");
+    address public treasury = makeAddr("blTreasury");
+
+    function setUp() public {
+        taker = vm.addr(takerKey);
+
+        busdc = new MockBlacklistableERC20("USD Coin", "USDC", 6);
+        staking = new GauloiStaking(address(busdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
+        escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
+        disputes = new GauloiDisputes(
+            address(staking), address(escrow), address(busdc),
+            24 hours, 200, 250e6, treasury, owner
+        );
+        resolver = new MockResolver();
+
+        vm.startPrank(owner);
+        staking.setEscrow(address(escrow));
+        staking.setDisputes(address(disputes));
+        escrow.setDisputes(address(disputes));
+        escrow.addSupportedToken(address(busdc));
+        disputes.setResolver(DEST_CHAIN_ID, address(resolver));
+        vm.stopPrank();
+
+        busdc.mint(maker1Addr, 1_000_000e6);
+        busdc.mint(challenger, 1_000_000e6);
+        busdc.mint(taker, 1_000_000e6);
+
+        vm.startPrank(maker1Addr);
+        busdc.approve(address(staking), 50_000e6);
+        staking.stake(50_000e6);
+        vm.stopPrank();
+
+        vm.prank(taker);
+        busdc.approve(address(escrow), type(uint256).max);
+        vm.prank(challenger);
+        busdc.approve(address(disputes), type(uint256).max);
+    }
+
+    function test_resolve_valid_blacklistedMakerCannotBlock() public {
+        DataTypes.Order memory order = DataTypes.Order({
+            taker: taker,
+            inputToken: address(busdc),
+            inputAmount: 10_000e6,
+            outputToken: address(busdc),
+            minOutputAmount: 9_990e6,
+            destinationChainId: DEST_CHAIN_ID,
+            destinationAddress: DEST_ADDRESS,
+            expiry: block.timestamp + 1 hours,
+            nonce: 1
+        });
+
+        // Sign with escrow's domain
+        bytes memory sig = _signOrderFor(order);
+
+        vm.prank(maker1Addr);
+        bytes32 intentId = escrow.executeOrder(order, sig);
+        vm.prank(maker1Addr);
+        escrow.submitFill(intentId, keccak256("tx"));
+
+        vm.prank(challenger);
+        disputes.challenge(order);
+
+        // Maker gets blacklisted mid-dispute
+        busdc.blacklist(maker1Addr);
+
+        resolver.setVerdict(IResolver.Verdict.Valid);
+
+        // Resolution completes despite the blacklisted maker
+        disputes.resolve(intentId, "");
+
+        DataTypes.Dispute memory disp = disputes.getDispute(intentId);
+        assertTrue(disp.resolved);
+        assertTrue(disp.fillDeemedValid);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
+        // Maker's bond share stranded in disputes, escrow amount stranded in escrow —
+        // both recoverable by owner rescue paths; the dispute itself cannot be bricked
+    }
+
+    function _signOrderFor(DataTypes.Order memory order) internal view returns (bytes memory) {
+        return _signOrder(takerKey, order);
+    }
 }


### PR DESCRIPTION
Implements #54 (umbrella #2). Vote machinery deleted; IResolver terminal arbiters per corridor; flipped default. 171 tests passing. Details in the commit message and README spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)