### PR TITLE
feat(escrow): per-corridor settlement and resolution windows

### DIFF
--- a/contracts/src/GauloiDisputes.sol
+++ b/contracts/src/GauloiDisputes.sol
@@ -45,6 +45,10 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
     // Corridor resolvers: destination chain id => terminal arbiter
     mapping(uint256 => IResolver) public resolvers;
 
+    // Per-corridor resolution window overrides (0 = use default) — proof corridors
+    // can afford tighter defense deadlines than council corridors
+    mapping(uint256 => uint256) public corridorResolutionWindow;
+
     mapping(bytes32 => DataTypes.Dispute) internal _disputes;
     mapping(bytes32 => DataTypes.Order) internal _disputeOrders;
 
@@ -99,6 +103,16 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         emit ResolutionWindowUpdated(oldValue, newWindow);
     }
 
+    function setCorridorResolutionWindow(uint256 destinationChainId, uint256 newWindow) external onlyOwner {
+        require(
+            newWindow == 0 || (newWindow >= 1 hours && newWindow <= 30 days),
+            "GauloiDisputes: window out of range"
+        );
+        uint256 oldValue = corridorResolutionWindow[destinationChainId];
+        corridorResolutionWindow[destinationChainId] = newWindow;
+        emit CorridorResolutionWindowUpdated(destinationChainId, oldValue, newWindow);
+    }
+
     function setDisputeBondParams(uint256 newBps, uint256 newMinBond) external onlyOwner {
         require(newBps <= 10_000, "GauloiDisputes: bps exceeds 100%");
         disputeBondBps = newBps;
@@ -140,7 +154,7 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
             intentId: intentId,
             challenger: msg.sender,
             bondAmount: bondAmount,
-            disputeDeadline: block.timestamp + disputeResolutionDuration,
+            disputeDeadline: block.timestamp + resolutionWindowFor(order.destinationChainId),
             resolved: false,
             fillDeemedValid: false
         });
@@ -302,5 +316,10 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
 
     function disputeResolutionWindow() external view returns (uint256) {
         return disputeResolutionDuration;
+    }
+
+    function resolutionWindowFor(uint256 destinationChainId) public view returns (uint256) {
+        uint256 corridorWindow = corridorResolutionWindow[destinationChainId];
+        return corridorWindow == 0 ? disputeResolutionDuration : corridorWindow;
     }
 }

--- a/contracts/src/GauloiEscrow.sol
+++ b/contracts/src/GauloiEscrow.sol
@@ -21,6 +21,12 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
     uint256 public settlementWindowDuration;
     uint256 public commitmentTimeoutDuration;
 
+    // Per-corridor settlement window overrides (destination chain id => window).
+    // 0 means "use the default". The window is an insurance premium priced by
+    // corridor verifiability: provable corridors shrink toward destination
+    // finality, council corridors stay wide.
+    mapping(uint256 => uint256) public corridorSettlementWindow;
+
     bytes32 public immutable domainSeparator;
 
     // Token whitelist
@@ -68,6 +74,16 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
         uint256 oldValue = settlementWindowDuration;
         settlementWindowDuration = newWindow;
         emit SettlementWindowUpdated(oldValue, newWindow);
+    }
+
+    function setCorridorSettlementWindow(uint256 destinationChainId, uint256 newWindow) external onlyOwner {
+        require(
+            newWindow == 0 || (newWindow >= 1 minutes && newWindow <= 7 days),
+            "GauloiEscrow: window out of range"
+        );
+        uint256 oldValue = corridorSettlementWindow[destinationChainId];
+        corridorSettlementWindow[destinationChainId] = newWindow;
+        emit CorridorSettlementWindowUpdated(destinationChainId, oldValue, newWindow);
     }
 
     function setCommitmentTimeout(uint256 newTimeout) external onlyOwner {
@@ -161,7 +177,11 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
         );
     }
 
-    function submitFill(bytes32 intentId, bytes32 destinationTxHash) external nonReentrant {
+    /// @dev Takes the full order so the dispute window can be priced per corridor.
+    ///      The order is bound to the commitment via intentId — a mismatched order
+    ///      computes a different id and fails the state/maker checks.
+    function submitFill(DataTypes.Order calldata order, bytes32 destinationTxHash) external nonReentrant {
+        bytes32 intentId = IntentLib.computeIntentId(order);
         DataTypes.Commitment storage commitment = _commitments[intentId];
         require(commitment.state == DataTypes.IntentState.Committed, "GauloiEscrow: not committed");
         require(commitment.maker == msg.sender, "GauloiEscrow: not committed maker");
@@ -170,7 +190,8 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
 
         commitment.state = DataTypes.IntentState.Filled;
         commitment.fillTxHash = destinationTxHash;
-        commitment.disputeWindowEnd = SafeCast.toUint40(block.timestamp + settlementWindowDuration);
+        commitment.disputeWindowEnd =
+            SafeCast.toUint40(block.timestamp + settlementWindowFor(order.destinationChainId));
 
         emit FillSubmitted(intentId, msg.sender, destinationTxHash, commitment.disputeWindowEnd);
     }
@@ -304,6 +325,11 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
 
     function settlementWindow() external view returns (uint256) {
         return settlementWindowDuration;
+    }
+
+    function settlementWindowFor(uint256 destinationChainId) public view returns (uint256) {
+        uint256 corridorWindow = corridorSettlementWindow[destinationChainId];
+        return corridorWindow == 0 ? settlementWindowDuration : corridorWindow;
     }
 
     function commitmentTimeout() external view returns (uint256) {

--- a/contracts/src/interfaces/IGauloiDisputes.sol
+++ b/contracts/src/interfaces/IGauloiDisputes.sol
@@ -13,6 +13,7 @@ interface IGauloiDisputes {
     event ChallengerRewardFailed(bytes32 indexed intentId, address indexed challenger, uint256 amount);
     event TreasuryTransferFailed(bytes32 indexed intentId, uint256 amount);
     event ResolutionWindowUpdated(uint256 oldValue, uint256 newValue);
+    event CorridorResolutionWindowUpdated(uint256 indexed destinationChainId, uint256 oldValue, uint256 newValue);
     event BondParamsUpdated(uint256 newBps, uint256 newMinBond);
     event SlashCurveUpdated(uint256 base, uint256 k, uint256 max);
     event ResolverUpdated(uint256 indexed destinationChainId, address indexed oldResolver, address indexed newResolver);

--- a/contracts/src/interfaces/IGauloiEscrow.sol
+++ b/contracts/src/interfaces/IGauloiEscrow.sol
@@ -28,6 +28,7 @@ interface IGauloiEscrow {
     event Unpaused(address indexed caller);
     event DisputesUpdated(address oldDisputes, address newDisputes);
     event SettlementWindowUpdated(uint256 oldValue, uint256 newValue);
+    event CorridorSettlementWindowUpdated(uint256 indexed destinationChainId, uint256 oldValue, uint256 newValue);
     event CommitmentTimeoutUpdated(uint256 oldValue, uint256 newValue);
     event TokenAdded(address indexed token);
     event TokenRemoved(address indexed token);
@@ -39,8 +40,8 @@ interface IGauloiEscrow {
         bytes calldata takerSignature
     ) external returns (bytes32 intentId);
 
-    // Maker submits fill evidence (destination tx hash)
-    function submitFill(bytes32 intentId, bytes32 destinationTxHash) external;
+    // Maker submits fill evidence (destination tx hash); order binds via intentId
+    function submitFill(DataTypes.Order calldata order, bytes32 destinationTxHash) external;
 
     // Settle a single intent after dispute window
     function settle(DataTypes.Order calldata order) external;
@@ -62,5 +63,6 @@ interface IGauloiEscrow {
     // --- View functions ---
     function getCommitment(bytes32 intentId) external view returns (DataTypes.Commitment memory);
     function settlementWindow() external view returns (uint256);
+    function settlementWindowFor(uint256 destinationChainId) external view returns (uint256);
     function commitmentTimeout() external view returns (uint256);
 }

--- a/contracts/test/fork/ForkSettlement.t.sol
+++ b/contracts/test/fork/ForkSettlement.t.sol
@@ -179,7 +179,7 @@ contract ForkSettlementTest is Test {
 
         // 2. MakerA submits fill evidence
         vm.prank(makerA);
-        escrow.submitFill(intentId, keccak256("arb_tx_real"));
+        escrow.submitFill(order, keccak256("arb_tx_real"));
 
         // 3. Wait for settlement window
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
@@ -212,7 +212,7 @@ contract ForkSettlementTest is Test {
 
         // Maker submits fill
         vm.prank(makerA);
-        escrow.submitFill(intentId, keccak256("fill_usdt"));
+        escrow.submitFill(order, keccak256("fill_usdt"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
         escrow.settle(order);
@@ -257,10 +257,10 @@ contract ForkSettlementTest is Test {
             bytes memory sig = _signOrder(orders[i]);
 
             vm.prank(makerA);
-            bytes32 intentId = escrow.executeOrder(orders[i], sig);
+            escrow.executeOrder(orders[i], sig);
 
             vm.startPrank(makerA);
-            escrow.submitFill(intentId, keccak256(abi.encode("fill", i)));
+            escrow.submitFill(orders[i], keccak256(abi.encode("fill", i)));
             vm.stopPrank();
         }
 
@@ -287,7 +287,7 @@ contract ForkSettlementTest is Test {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(makerA);
-        escrow.submitFill(intentId, fakeFill);
+        escrow.submitFill(order, fakeFill);
 
         uint256 makerAStake = staking.getMakerInfo(makerA).stakedAmount;
 

--- a/contracts/test/gas/GasBenchmark.t.sol
+++ b/contracts/test/gas/GasBenchmark.t.sol
@@ -129,10 +129,10 @@ contract GasBenchmark is Test {
 
     function test_gas_submitFill() public {
         _stake(maker1, 50_000e6);
-        (bytes32 intentId, ) = _executeOrder(10_000e6);
+        (, DataTypes.Order memory order) = _executeOrder(10_000e6);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("dest_tx"));
+        escrow.submitFill(order, keccak256("dest_tx"));
     }
 
     function test_gas_settle() public {
@@ -280,7 +280,7 @@ contract GasBenchmark is Test {
     function _fillIntent(uint256 amount) internal returns (bytes32, DataTypes.Order memory) {
         (bytes32 id, DataTypes.Order memory order) = _executeOrder(amount);
         vm.startPrank(maker1);
-        escrow.submitFill(id, keccak256(abi.encodePacked("tx", id)));
+        escrow.submitFill(order, keccak256(abi.encodePacked("tx", id)));
         vm.stopPrank();
         return (id, order);
     }

--- a/contracts/test/integration/SettlementLoop.t.sol
+++ b/contracts/test/integration/SettlementLoop.t.sol
@@ -166,7 +166,7 @@ contract SettlementLoopTest is Test {
         // 2. MakerA fills on dest chain (simulated) and submits evidence
         bytes32 fillTx = keccak256("arb_tx_0x1234");
         vm.prank(makerA);
-        escrow.submitFill(intentId, fillTx);
+        escrow.submitFill(order, fillTx);
 
         // 3. Wait for settlement window
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
@@ -190,7 +190,7 @@ contract SettlementLoopTest is Test {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(makerA);
-        escrow.submitFill(intentId, keccak256("fill_tx"));
+        escrow.submitFill(order, keccak256("fill_tx"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
         escrow.settle(order);
@@ -217,7 +217,7 @@ contract SettlementLoopTest is Test {
             ids[i] = escrow.executeOrder(orders[i], sig);
 
             vm.prank(makerA);
-            escrow.submitFill(ids[i], keccak256(abi.encode("fill", i)));
+            escrow.submitFill(orders[i], keccak256(abi.encode("fill", i)));
         }
 
         assertEq(staking.getMakerInfo(makerA).activeExposure, 50_000e6);
@@ -273,7 +273,7 @@ contract SettlementLoopTest is Test {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(makerA);
-        escrow.submitFill(intentId, fillTx);
+        escrow.submitFill(order, fillTx);
 
         // MakerB challenges (incorrectly)
         uint256 bondAmount = disputes.calculateDisputeBond(20_000e6);
@@ -316,7 +316,7 @@ contract SettlementLoopTest is Test {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(makerA);
-        escrow.submitFill(intentId, fakeFillTx);
+        escrow.submitFill(order, fakeFillTx);
 
         // MakerB challenges (correctly)
         uint256 bondAmount = disputes.calculateDisputeBond(20_000e6);
@@ -364,7 +364,7 @@ contract SettlementLoopTest is Test {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(makerA);
-        escrow.submitFill(intentId, keccak256("fill"));
+        escrow.submitFill(order, keccak256("fill"));
 
         uint256 bondAmount = disputes.calculateDisputeBond(10_000e6);
         vm.startPrank(makerB);
@@ -401,7 +401,7 @@ contract SettlementLoopTest is Test {
         bytes32 id1 = escrow.executeOrder(order1, sig1);
 
         vm.prank(makerA);
-        escrow.submitFill(id1, keccak256("fill_a"));
+        escrow.submitFill(order1, keccak256("fill_a"));
 
         // Intent 2: filled by makerB
         DataTypes.Order memory order2 = _makeOrder(address(usdc), 15_000e6, address(usdc), 14_990e6);
@@ -411,7 +411,7 @@ contract SettlementLoopTest is Test {
         bytes32 id2 = escrow.executeOrder(order2, sig2);
 
         vm.prank(makerB);
-        escrow.submitFill(id2, keccak256("fill_b"));
+        escrow.submitFill(order2, keccak256("fill_b"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
 

--- a/contracts/test/unit/CouncilResolver.t.sol
+++ b/contracts/test/unit/CouncilResolver.t.sol
@@ -282,7 +282,7 @@ contract CouncilResolverIntegrationTest is BaseTest {
         vm.prank(makerAddr);
         bytes32 intentId = escrow.executeOrder(order, sig);
         vm.prank(makerAddr);
-        escrow.submitFill(intentId, keccak256("tx"));
+        escrow.submitFill(order, keccak256("tx"));
 
         // Challenge
         vm.prank(challengerAddr);
@@ -323,7 +323,7 @@ contract CouncilResolverIntegrationTest is BaseTest {
         vm.prank(makerAddr);
         bytes32 intentId = escrow.executeOrder(order, sig);
         vm.prank(makerAddr);
-        escrow.submitFill(intentId, keccak256("tx"));
+        escrow.submitFill(order, keccak256("tx"));
 
         vm.prank(challengerAddr);
         disputes.challenge(order);

--- a/contracts/test/unit/GauloiDisputes.t.sol
+++ b/contracts/test/unit/GauloiDisputes.t.sol
@@ -89,7 +89,7 @@ contract GauloiDisputesTest is BaseTest {
         bytes32 intentId = escrow.executeOrder(order, sig);
 
         vm.prank(maker1Addr);
-        escrow.submitFill(intentId, keccak256("dest_tx"));
+        escrow.submitFill(order, keccak256("dest_tx"));
 
         return (intentId, order);
     }
@@ -98,6 +98,36 @@ contract GauloiDisputesTest is BaseTest {
         vm.prank(who);
         disputes.challenge(order);
         return IntentLib.computeIntentId(order);
+    }
+
+    // =========================================================================
+    // Corridor resolution windows
+    // =========================================================================
+
+    function test_challenge_corridorResolutionWindowOverride() public {
+        vm.prank(owner);
+        disputes.setCorridorResolutionWindow(DEST_CHAIN_ID, 2 hours);
+        assertEq(disputes.resolutionWindowFor(DEST_CHAIN_ID), 2 hours);
+        assertEq(disputes.resolutionWindowFor(999), RESOLUTION_WINDOW);
+
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
+        _challengeAs(challenger, order);
+
+        assertEq(disputes.getDispute(intentId).disputeDeadline, block.timestamp + 2 hours);
+    }
+
+    function test_setCorridorResolutionWindow_bounds() public {
+        vm.startPrank(owner);
+        vm.expectRevert("GauloiDisputes: window out of range");
+        disputes.setCorridorResolutionWindow(DEST_CHAIN_ID, 30 minutes);
+        vm.expectRevert("GauloiDisputes: window out of range");
+        disputes.setCorridorResolutionWindow(DEST_CHAIN_ID, 31 days);
+        disputes.setCorridorResolutionWindow(DEST_CHAIN_ID, 0); // clearing allowed
+        vm.stopPrank();
+
+        vm.prank(challenger);
+        vm.expectRevert();
+        disputes.setCorridorResolutionWindow(DEST_CHAIN_ID, 2 hours);
     }
 
     // =========================================================================
@@ -357,7 +387,7 @@ contract GauloiDisputesTest is BaseTest {
         vm.prank(maker1Addr);
         bytes32 intentId = escrow.executeOrder(order, sig);
         vm.prank(maker1Addr);
-        escrow.submitFill(intentId, keccak256("tx"));
+        escrow.submitFill(order, keccak256("tx"));
 
         _challengeAs(challenger, order);
 
@@ -607,7 +637,7 @@ contract GauloiDisputesBlacklistTest is BaseTest {
         vm.prank(maker1Addr);
         bytes32 intentId = escrow.executeOrder(order, sig);
         vm.prank(maker1Addr);
-        escrow.submitFill(intentId, keccak256("tx"));
+        escrow.submitFill(order, keccak256("tx"));
 
         vm.prank(challenger);
         disputes.challenge(order);

--- a/contracts/test/unit/GauloiEscrow.t.sol
+++ b/contracts/test/unit/GauloiEscrow.t.sol
@@ -172,7 +172,7 @@ contract GauloiEscrowTest is BaseTest {
         bytes32 txHash = keccak256("dest_tx_hash");
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, txHash);
+        escrow.submitFill(order, txHash);
 
         DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
         assertTrue(commitment.state == DataTypes.IntentState.Filled);
@@ -180,31 +180,76 @@ contract GauloiEscrowTest is BaseTest {
         assertEq(commitment.disputeWindowEnd, uint40(block.timestamp + SETTLEMENT_WINDOW));
     }
 
+    function test_submitFill_corridorWindowOverride() public {
+        // Provable corridor gets a tighter window than the default
+        vm.prank(owner);
+        escrow.setCorridorSettlementWindow(DEST_CHAIN_ID, 2 minutes);
+        assertEq(escrow.settlementWindowFor(DEST_CHAIN_ID), 2 minutes);
+        assertEq(escrow.settlementWindowFor(999), SETTLEMENT_WINDOW); // others default
+
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        vm.prank(maker1);
+        escrow.submitFill(order, keccak256("hash"));
+
+        assertEq(
+            escrow.getCommitment(intentId).disputeWindowEnd,
+            uint40(block.timestamp + 2 minutes)
+        );
+
+        // Clearing the override restores the default
+        vm.prank(owner);
+        escrow.setCorridorSettlementWindow(DEST_CHAIN_ID, 0);
+        assertEq(escrow.settlementWindowFor(DEST_CHAIN_ID), SETTLEMENT_WINDOW);
+    }
+
+    function test_setCorridorSettlementWindow_bounds() public {
+        vm.startPrank(owner);
+        vm.expectRevert("GauloiEscrow: window out of range");
+        escrow.setCorridorSettlementWindow(DEST_CHAIN_ID, 30 seconds);
+        vm.expectRevert("GauloiEscrow: window out of range");
+        escrow.setCorridorSettlementWindow(DEST_CHAIN_ID, 8 days);
+        vm.stopPrank();
+
+        vm.prank(maker1);
+        vm.expectRevert();
+        escrow.setCorridorSettlementWindow(DEST_CHAIN_ID, 2 minutes);
+    }
+
+    function test_submitFill_orderMismatchReverts() public {
+        // A different order than the one executed computes a different intentId
+        (, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        order.inputAmount = 20_000e6; // tamper
+
+        vm.prank(maker1);
+        vm.expectRevert("GauloiEscrow: not committed");
+        escrow.submitFill(order, keccak256("hash"));
+    }
+
     function test_submitFill_notCommittedMaker_reverts() public {
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         _stakeMaker(maker2, 50_000e6);
         vm.prank(maker2);
         vm.expectRevert("GauloiEscrow: not committed maker");
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
     }
 
     function test_submitFill_afterCommitmentExpiry_reverts() public {
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.warp(block.timestamp + COMMITMENT_TIMEOUT + 1);
 
         vm.prank(maker1);
         vm.expectRevert("GauloiEscrow: commitment expired");
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
     }
 
     function test_submitFill_emptyTxHash_reverts() public {
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
         vm.expectRevert("GauloiEscrow: empty tx hash");
-        escrow.submitFill(intentId, bytes32(0));
+        escrow.submitFill(order, bytes32(0));
     }
 
     // --- Settle ---
@@ -213,7 +258,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
 
@@ -230,7 +275,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW - 1);
 
@@ -252,8 +297,8 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 id2, DataTypes.Order memory order2) = _createAndExecuteOrder(5_000e6, 4_990e6, maker1);
 
         vm.startPrank(maker1);
-        escrow.submitFill(id1, keccak256("hash1"));
-        escrow.submitFill(id2, keccak256("hash2"));
+        escrow.submitFill(order1, keccak256("hash1"));
+        escrow.submitFill(order2, keccak256("hash2"));
         vm.stopPrank();
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
@@ -275,8 +320,8 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 id2, DataTypes.Order memory order2) = _createAndExecuteOrder(5_000e6, 4_990e6, maker1);
 
         vm.startPrank(maker1);
-        escrow.submitFill(id1, keccak256("hash1"));
-        escrow.submitFill(id2, keccak256("hash2"));
+        escrow.submitFill(order1, keccak256("hash1"));
+        escrow.submitFill(order2, keccak256("hash2"));
         vm.stopPrank();
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
@@ -332,7 +377,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.warp(block.timestamp + 2 hours);
 
@@ -344,10 +389,10 @@ contract GauloiEscrowTest is BaseTest {
     // --- Disputes integration ---
 
     function test_setDisputed() public {
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.prank(mockDisputes);
         escrow.setDisputed(intentId);
@@ -359,7 +404,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.prank(mockDisputes);
         escrow.setDisputed(intentId);
@@ -377,7 +422,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.prank(mockDisputes);
         escrow.setDisputed(intentId);
@@ -392,10 +437,10 @@ contract GauloiEscrowTest is BaseTest {
     }
 
     function test_setDisputed_notDisputes_reverts() public {
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.prank(maker1);
         vm.expectRevert("GauloiEscrow: caller is not disputes");
@@ -443,7 +488,7 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("hash"));
+        escrow.submitFill(order, keccak256("hash"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
 
@@ -475,7 +520,7 @@ contract GauloiEscrowTest is BaseTest {
 
     function test_executeOrder_normalTimestamp_succeeds() public {
         // Sanity check: normal durations work after SafeCast is in place
-        (bytes32 intentId, ) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
 
         DataTypes.Commitment memory c = escrow.getCommitment(intentId);
         assertEq(c.commitmentDeadline, uint40(block.timestamp + COMMITMENT_TIMEOUT));
@@ -613,8 +658,8 @@ contract GauloiEscrowTest is BaseTest {
         (bytes32 id2, DataTypes.Order memory order2) = _createAndExecuteOrder(5_000e6, 4_990e6, maker1);
 
         vm.startPrank(maker1);
-        escrow.submitFill(id1, keccak256("hash1"));
-        escrow.submitFill(id2, keccak256("hash2"));
+        escrow.submitFill(order1, keccak256("hash1"));
+        escrow.submitFill(order2, keccak256("hash2"));
         vm.stopPrank();
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
@@ -695,7 +740,7 @@ contract GauloiEscrowTest is BaseTest {
         bytes32 intentId = bEscrow.executeOrder(order, sig);
 
         vm.prank(maker1);
-        bEscrow.submitFill(intentId, keccak256("hash"));
+        bEscrow.submitFill(order, keccak256("hash"));
 
         vm.warp(block.timestamp + SETTLEMENT_WINDOW);
 
@@ -765,7 +810,7 @@ contract GauloiEscrowTest is BaseTest {
 
         // Maker fills
         vm.prank(maker1);
-        escrow.submitFill(intentId, keccak256("real_tx_hash"));
+        escrow.submitFill(order, keccak256("real_tx_hash"));
         assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Filled);
 
         // Wait for dispute window


### PR DESCRIPTION
Implements #57 (umbrella #2). submitFill(Order, txHash) breaking ABI change — off-chain wiring lands with #53. 192 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)