### PR TITLE
fix(contracts): v0.2 audit hardening

### DIFF
--- a/contracts/src/GauloiDisputes.sol
+++ b/contracts/src/GauloiDisputes.sol
@@ -145,6 +145,15 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         require(block.timestamp < commitment.disputeWindowEnd, "GauloiDisputes: window closed");
         require(msg.sender != commitment.maker, "GauloiDisputes: cannot challenge own fill");
 
+        // A dispute must be adjudicable. Without a resolver the only exit is the
+        // deadline default, which would let a griefer force-slash an honest,
+        // registry-recorded fill on an unconfigured corridor. Require the
+        // corridor's arbiter to exist before the challenge can open.
+        require(
+            address(resolvers[order.destinationChainId]) != address(0),
+            "GauloiDisputes: no resolver for corridor"
+        );
+
         uint256 bondAmount = calculateDisputeBond(order.inputAmount);
 
         // Transfer bond from challenger
@@ -203,15 +212,24 @@ contract GauloiDisputes is IGauloiDisputes, Ownable, ReentrancyGuard {
         require(block.timestamp > disp.disputeDeadline, "GauloiDisputes: deadline not passed");
 
         DataTypes.Commitment memory commitment = escrow.getCommitment(intentId);
+        DataTypes.Order storage order = _disputeOrders[intentId];
 
-        // The maker failed to defend a challenged fill: resolves against the fill.
-        // Safe because registry-recorded fills give every honest maker a defense —
-        // this default punishes silent fraud, not honest fills.
+        // If the corridor lost its resolver after the challenge opened, the maker
+        // can no longer defend — voiding in the maker's favor is the griefing-safe
+        // direction (owner removing an arbiter must not auto-convict). Otherwise
+        // the maker failed to defend a defendable fill: silence convicts.
+        bool defendable = address(resolvers[order.destinationChainId]) != address(0);
+
         disp.resolved = true;
-        disp.fillDeemedValid = false;
-        _resolveAsInvalid(intentId, commitment, disp);
+        disp.fillDeemedValid = defendable ? false : true;
 
-        emit DisputeResolved(intentId, false);
+        if (defendable) {
+            _resolveAsInvalid(intentId, commitment, disp);
+        } else {
+            _resolveAsValid(intentId, commitment, disp);
+        }
+
+        emit DisputeResolved(intentId, !defendable);
     }
 
     // --- Internal resolution ---

--- a/contracts/src/GauloiEscrow.sol
+++ b/contracts/src/GauloiEscrow.sol
@@ -44,6 +44,10 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
     // Commitment storage (intentId → Commitment)
     mapping(bytes32 => DataTypes.Commitment) internal _commitments;
 
+    // Live escrowed liability per token — the sum currently owed to takers/makers
+    // across open commitments. rescueTokens can only touch balance above this.
+    mapping(address => uint256) public escrowedBalance;
+
     bool public paused;
 
     modifier whenNotPaused() {
@@ -53,6 +57,14 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
 
     modifier onlyDisputes() {
         require(msg.sender == disputes, "GauloiEscrow: caller is not disputes");
+        _;
+    }
+
+    modifier onlyOwnerOrDisputes() {
+        require(
+            msg.sender == owner() || msg.sender == disputes,
+            "GauloiEscrow: caller is not owner or disputes"
+        );
         _;
     }
 
@@ -128,15 +140,21 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
         emit TokenRemoved(token);
     }
 
-    /// @dev Recover tokens stuck from failed dispute-resolution transfers
+    /// @dev Recover only the surplus above live escrow liability — tokens stranded
+    ///      by failed transfers or sent in by mistake. Cannot touch funds backing
+    ///      open commitments, so the owner can never rug escrowed taker/maker funds.
     function rescueTokens(address token, address to, uint256 amount) external onlyOwner nonReentrant {
         require(to != address(0), "GauloiEscrow: zero address");
+        uint256 liability = escrowedBalance[token];
+        uint256 bal = IERC20(token).balanceOf(address(this));
+        uint256 surplus = bal > liability ? bal - liability : 0;
+        require(amount <= surplus, "GauloiEscrow: exceeds rescuable surplus");
         IERC20(token).safeTransfer(to, amount);
     }
 
     // --- Pause ---
 
-    function pause() external onlyDisputes {
+    function pause() external onlyOwnerOrDisputes {
         paused = true;
         emit Paused(msg.sender);
     }
@@ -199,6 +217,9 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
             IERC20(order.inputToken).balanceOf(address(this)) - balBefore == order.inputAmount,
             "GauloiEscrow: fee-on-transfer token"
         );
+
+        // Record the new escrow liability (checked exact above)
+        escrowedBalance[order.inputToken] += order.inputAmount;
     }
 
     /// @dev Takes the full order so the dispute window can be priced per corridor.
@@ -258,6 +279,10 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
     ///      rescueTokens) — and, unlike try/catch on IERC20.transfer, it
     ///      reports success correctly for no-return-data tokens (USDT).
     function _payoutMaker(bytes32 intentId, address maker, address token, uint256 amount) internal {
+        // Liability discharged whether or not the transfer succeeds — a failed
+        // transfer leaves the funds as recoverable surplus, not live escrow.
+        escrowedBalance[token] -= amount;
+
         uint256 fee = (amount * protocolFeeBps) / 10_000;
         uint256 makerAmount = amount - fee;
 
@@ -279,6 +304,8 @@ contract GauloiEscrow is IGauloiEscrow, Ownable, ReentrancyGuard {
     /// @dev Taker refund — never fee'd. tryTransfer so a blacklisted taker
     ///      cannot block exposure release (funds recoverable via rescueTokens)
     function _refundTaker(bytes32 intentId, address taker, address token, uint256 amount) internal {
+        escrowedBalance[token] -= amount;
+
         if (IERC20(token).tryTransfer(taker, amount)) {
             emit IntentReclaimed(intentId, taker);
         } else {

--- a/contracts/src/GauloiFillRegistry.sol
+++ b/contracts/src/GauloiFillRegistry.sol
@@ -6,11 +6,13 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IGauloiFillRegistry} from "./interfaces/IGauloiFillRegistry.sol";
 
-/// @notice Destination-side fill registry. Makes fills canonical, unique, on-chain facts:
-///         one fill per intent, one intent per fill. Deployed on every chain Gauloi
-///         delivers to; makers route destination transfers through `fill()` instead of
-///         bare ERC-20 transfers, so a fill's existence and parameters can be checked
-///         (or storage-proven) against a single mapping slot.
+/// @notice Destination-side fill registry. Makes fills canonical on-chain facts,
+///         recorded per (intentId, filler): a given filler records an intent at most
+///         once, and distinct fillers have independent slots so no one can squat the
+///         committed maker's slot. Deployed on every chain Gauloi delivers to; makers
+///         route destination transfers through `fill()` instead of bare ERC-20
+///         transfers, so a fill's existence and parameters can be checked (or
+///         storage-proven) against a single mapping slot — the committed maker's.
 ///
 ///         Deliberately permissionless and admin-free: the registry records transfers,
 ///         it does not judge them. Whether a fill satisfies an order (token, recipient,

--- a/contracts/src/GauloiFillRegistry.sol
+++ b/contracts/src/GauloiFillRegistry.sol
@@ -21,7 +21,14 @@ import {IGauloiFillRegistry} from "./interfaces/IGauloiFillRegistry.sol";
 contract GauloiFillRegistry is IGauloiFillRegistry, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    // intentId => keccak256(abi.encode(token, recipient, amount, filler, block.number))
+    // keccak256(intentId, filler) => keccak256(abi.encode(token, recipient, amount, filler, block.number))
+    //
+    // Keyed by (intentId, filler), not intentId alone. A fill is a claim by a
+    // specific filler; the slot must belong to the filler who made it. Otherwise
+    // anyone could front-run the committed maker's destination fill with a dust
+    // transfer and permanently occupy the intent's only slot — a cheap DoS
+    // against makers. The resolver looks up the committed maker's slot
+    // specifically, so a squatter's slot is simply ignored.
     mapping(bytes32 => bytes32) internal _fills;
 
     function fill(
@@ -34,10 +41,12 @@ contract GauloiFillRegistry is IGauloiFillRegistry, ReentrancyGuard {
         require(token != address(0), "GauloiFillRegistry: zero token");
         require(recipient != address(0), "GauloiFillRegistry: zero recipient");
         require(amount > 0, "GauloiFillRegistry: zero amount");
-        require(_fills[intentId] == bytes32(0), "GauloiFillRegistry: already filled");
+
+        bytes32 slot = _slot(intentId, msg.sender);
+        require(_fills[slot] == bytes32(0), "GauloiFillRegistry: already filled");
 
         // Effects before interaction (CEI pattern)
-        _fills[intentId] = computeFillCommitment(token, recipient, amount, msg.sender, block.number);
+        _fills[slot] = computeFillCommitment(token, recipient, amount, msg.sender, block.number);
 
         emit Filled(intentId, token, recipient, amount, msg.sender);
 
@@ -53,12 +62,16 @@ contract GauloiFillRegistry is IGauloiFillRegistry, ReentrancyGuard {
 
     // --- View functions ---
 
-    function getFill(bytes32 intentId) external view returns (bytes32) {
-        return _fills[intentId];
+    function getFill(bytes32 intentId, address filler) external view returns (bytes32) {
+        return _fills[_slot(intentId, filler)];
     }
 
-    function isFilled(bytes32 intentId) external view returns (bool) {
-        return _fills[intentId] != bytes32(0);
+    function isFilled(bytes32 intentId, address filler) external view returns (bool) {
+        return _fills[_slot(intentId, filler)] != bytes32(0);
+    }
+
+    function _slot(bytes32 intentId, address filler) internal pure returns (bytes32) {
+        return keccak256(abi.encode(intentId, filler));
     }
 
     function computeFillCommitment(

--- a/contracts/src/interfaces/IGauloiFillRegistry.sol
+++ b/contracts/src/interfaces/IGauloiFillRegistry.sol
@@ -11,8 +11,11 @@ interface IGauloiFillRegistry {
         address filler
     );
 
-    // Deliver `amount` of `token` to `recipient` and record the fill against `intentId`.
-    // Exactly one fill per intent — repeat calls for the same intentId revert.
+    // Deliver `amount` of `token` to `recipient` and record the fill against
+    // (intentId, msg.sender). One fill per (intent, filler) — a given filler
+    // cannot record the same intent twice, but distinct fillers have independent
+    // slots so no one can squat another maker's slot. Resolvers read the
+    // committed maker's slot; other fillers' records are ignored.
     function fill(bytes32 intentId, address token, address recipient, uint256 amount) external;
 
     // --- View functions ---

--- a/contracts/src/interfaces/IGauloiFillRegistry.sol
+++ b/contracts/src/interfaces/IGauloiFillRegistry.sol
@@ -17,10 +17,11 @@ interface IGauloiFillRegistry {
 
     // --- View functions ---
 
-    // Commitment hash for a recorded fill (bytes32(0) if unfilled)
-    function getFill(bytes32 intentId) external view returns (bytes32);
+    // Commitment hash for a fill recorded by `filler` (bytes32(0) if none).
+    // Keyed by (intentId, filler): resolvers look up the committed maker's slot.
+    function getFill(bytes32 intentId, address filler) external view returns (bytes32);
 
-    function isFilled(bytes32 intentId) external view returns (bool);
+    function isFilled(bytes32 intentId, address filler) external view returns (bool);
 
     // Recompute a fill commitment from its preimage — used by verifiers
     // checking a proven storage slot against claimed fill parameters

--- a/contracts/test/unit/GauloiDisputes.t.sol
+++ b/contracts/test/unit/GauloiDisputes.t.sol
@@ -370,8 +370,9 @@ contract GauloiDisputesTest is BaseTest {
         disputes.resolve(intentId, "");
     }
 
-    function test_resolve_revertsIfNoResolverForCorridor() public {
-        // Order to a corridor with no resolver configured
+    function test_challenge_revertsIfNoResolverForCorridor() public {
+        // A fill to a corridor with no resolver cannot be challenged at all —
+        // otherwise the deadline default would force-slash an undefendable maker
         DataTypes.Order memory order = DataTypes.Order({
             taker: taker,
             inputToken: address(usdc),
@@ -389,10 +390,29 @@ contract GauloiDisputesTest is BaseTest {
         vm.prank(maker1Addr);
         escrow.submitFill(order, keccak256("tx"));
 
+        vm.prank(challenger);
+        vm.expectRevert("GauloiDisputes: no resolver for corridor");
+        disputes.challenge(order);
+    }
+
+    function test_finalizeExpired_voidsWhenResolverRemoved() public {
+        // Owner removes the resolver after a challenge opens — the maker can no
+        // longer defend, so finalize must void in the maker's favor, not convict
+        (bytes32 intentId, DataTypes.Order memory order) = _createAndFillIntent(10_000e6);
         _challengeAs(challenger, order);
 
-        vm.expectRevert("GauloiDisputes: no resolver for corridor");
-        disputes.resolve(intentId, "");
+        vm.prank(owner);
+        disputes.setResolver(DEST_CHAIN_ID, address(0));
+
+        vm.warp(block.timestamp + RESOLUTION_WINDOW + 1);
+
+        uint256 makerStakeBefore = staking.getStake(maker1Addr);
+        disputes.finalizeExpiredDispute(intentId);
+
+        // Resolved valid: maker NOT slashed, intent settled
+        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
+        assertEq(staking.getStake(maker1Addr), makerStakeBefore);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
     }
 
     function test_resolve_passesArgsToResolver() public {

--- a/contracts/test/unit/GauloiEscrow.t.sol
+++ b/contracts/test/unit/GauloiEscrow.t.sol
@@ -603,14 +603,24 @@ contract GauloiEscrowTest is BaseTest {
 
     // --- Pause ---
 
-    function test_pause_onlyDisputes() public {
+    function test_pause_ownerOrDisputes() public {
+        // A random account cannot pause
         vm.prank(maker1);
-        vm.expectRevert("GauloiEscrow: caller is not disputes");
+        vm.expectRevert("GauloiEscrow: caller is not owner or disputes");
         escrow.pause();
 
+        // Owner can pause (emergency stop — disputes no longer auto-pauses in v2)
         vm.prank(owner);
-        vm.expectRevert("GauloiEscrow: caller is not disputes");
         escrow.pause();
+        assertTrue(escrow.paused());
+
+        vm.prank(owner);
+        escrow.unpause();
+
+        // Disputes contract can also pause
+        vm.prank(mockDisputes);
+        escrow.pause();
+        assertTrue(escrow.paused());
     }
 
     function test_unpause_onlyOwner() public {
@@ -953,6 +963,56 @@ contract GauloiEscrowTest is BaseTest {
         assertEq(bToken.balanceOf(taker), takerBalBefore);
         // Funds still in escrow (recoverable via rescueTokens)
         assertEq(bToken.balanceOf(address(bEscrow)), 10_000e6);
+    }
+
+    // --- rescueTokens surplus accounting ---
+
+    function test_rescueTokens_cannotTouchLiveEscrow() public {
+        // A live commitment is escrow liability, not rescuable surplus
+        _createAndExecuteOrder(10_000e6, 9_990e6, maker1);
+        assertEq(escrow.escrowedBalance(address(usdc)), 10_000e6);
+
+        vm.prank(owner);
+        vm.expectRevert("GauloiEscrow: exceeds rescuable surplus");
+        escrow.rescueTokens(address(usdc), owner, 1);
+
+        // Tokens sent in by mistake ARE rescuable, up to the surplus
+        usdc.mint(address(escrow), 500e6);
+        vm.startPrank(owner);
+        vm.expectRevert("GauloiEscrow: exceeds rescuable surplus");
+        escrow.rescueTokens(address(usdc), owner, 501e6);
+        escrow.rescueTokens(address(usdc), owner, 500e6);
+        vm.stopPrank();
+        assertEq(usdc.balanceOf(owner), 500e6);
+    }
+
+    function test_rescueTokens_recoversStrandedAfterFailedTransfer() public {
+        (MockBlacklistableERC20 bToken,, GauloiEscrow bEscrow) = _deployBlacklistEscrow();
+
+        DataTypes.Order memory order = DataTypes.Order({
+            taker: taker, inputToken: address(bToken), inputAmount: 10_000e6,
+            outputToken: address(bToken), minOutputAmount: 9_990e6,
+            destinationChainId: DEST_CHAIN_ID, destinationAddress: DEST_ADDRESS,
+            expiry: block.timestamp + 1 hours, nonce: 0
+        });
+        bytes memory sig = _signOrderForEscrow(bEscrow, takerKey, order);
+
+        vm.prank(maker1);
+        bytes32 intentId = bEscrow.executeOrder(order, sig);
+        vm.prank(maker1);
+        bEscrow.submitFill(order, keccak256("hash"));
+        vm.warp(block.timestamp + SETTLEMENT_WINDOW);
+
+        // Blacklisted maker → transfer fails, but liability is discharged so the
+        // stranded funds become rescuable surplus
+        bToken.blacklist(maker1);
+        bEscrow.settle(order);
+        assertEq(bEscrow.escrowedBalance(address(bToken)), 0);
+
+        vm.prank(owner);
+        bEscrow.rescueTokens(address(bToken), owner, 10_000e6);
+        assertEq(bToken.balanceOf(owner), 10_000e6);
+        assertEq(intentId, IntentLib.computeIntentId(order));
     }
 
     // --- Happy path end-to-end ---

--- a/contracts/test/unit/GauloiFillRegistry.t.sol
+++ b/contracts/test/unit/GauloiFillRegistry.t.sol
@@ -52,8 +52,8 @@ contract GauloiFillRegistryTest is Test {
         bytes32 expected = registry.computeFillCommitment(
             address(usdc), recipient, FILL_AMOUNT, maker, block.number
         );
-        assertEq(registry.getFill(INTENT_ID), expected);
-        assertTrue(registry.isFilled(INTENT_ID));
+        assertEq(registry.getFill(INTENT_ID, maker), expected);
+        assertTrue(registry.isFilled(INTENT_ID, maker));
     }
 
     function test_Fill_EmitsEvent() public {
@@ -64,23 +64,37 @@ contract GauloiFillRegistryTest is Test {
         registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
     }
 
-    function test_Fill_RevertsOnDoubleFill() public {
+    function test_Fill_RevertsOnDoubleFill_sameFiller() public {
         vm.prank(maker);
         registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
 
-        // Same intent, same filler
+        // Same intent, same filler — one fill per (intent, filler)
         vm.prank(maker);
         vm.expectRevert("GauloiFillRegistry: already filled");
         registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+    }
 
-        // Same intent, different filler and params — still one fill per intent
-        address other = makeAddr("other");
-        usdc.mint(other, FILL_AMOUNT);
-        vm.startPrank(other);
+    function test_Fill_squatterCannotBlockRealMaker() public {
+        // A squatter records the same intentId first. Under (intentId, filler)
+        // keying this occupies only the squatter's slot — the real maker's slot
+        // is independent, so the maker can still record their genuine fill.
+        address squatter = makeAddr("squatter");
+        address squatterDest = makeAddr("squatterDest");
+        usdc.mint(squatter, FILL_AMOUNT);
+        vm.startPrank(squatter);
         usdc.approve(address(registry), FILL_AMOUNT);
-        vm.expectRevert("GauloiFillRegistry: already filled");
-        registry.fill(INTENT_ID, address(usdc), other, FILL_AMOUNT);
+        registry.fill(INTENT_ID, address(usdc), squatterDest, 1); // dust to poison the intent
         vm.stopPrank();
+
+        // Real maker's fill still lands, and resolves against the maker's slot
+        vm.prank(maker);
+        registry.fill(INTENT_ID, address(usdc), recipient, FILL_AMOUNT);
+
+        assertTrue(registry.isFilled(INTENT_ID, maker));
+        assertEq(usdc.balanceOf(recipient), FILL_AMOUNT);
+        // The squatter's slot is a separate, ignored record
+        assertTrue(registry.isFilled(INTENT_ID, squatter));
+        assertFalse(registry.getFill(INTENT_ID, maker) == registry.getFill(INTENT_ID, squatter));
     }
 
     function test_Fill_DistinctIntentsSameParams() public {
@@ -92,8 +106,8 @@ contract GauloiFillRegistryTest is Test {
         vm.stopPrank();
 
         assertEq(usdc.balanceOf(recipient), 2 * FILL_AMOUNT);
-        assertTrue(registry.isFilled(keccak256("intent-a")));
-        assertTrue(registry.isFilled(keccak256("intent-b")));
+        assertTrue(registry.isFilled(keccak256("intent-a"), maker));
+        assertTrue(registry.isFilled(keccak256("intent-b"), maker));
     }
 
     function test_Fill_RevertsOnFeeOnTransferToken() public {
@@ -101,7 +115,7 @@ contract GauloiFillRegistryTest is Test {
         vm.expectRevert("GauloiFillRegistry: fee-on-transfer token");
         registry.fill(INTENT_ID, address(feeToken), recipient, FILL_AMOUNT);
 
-        assertFalse(registry.isFilled(INTENT_ID));
+        assertFalse(registry.isFilled(INTENT_ID, maker));
     }
 
     function test_Fill_RevertsWithoutApproval() public {
@@ -134,8 +148,8 @@ contract GauloiFillRegistryTest is Test {
     // --- views ---
 
     function test_GetFill_UnfilledIsZero() public view {
-        assertEq(registry.getFill(INTENT_ID), bytes32(0));
-        assertFalse(registry.isFilled(INTENT_ID));
+        assertEq(registry.getFill(INTENT_ID, maker), bytes32(0));
+        assertFalse(registry.isFilled(INTENT_ID, maker));
     }
 
     function test_ComputeFillCommitment_MatchesPreimage() public {
@@ -145,7 +159,7 @@ contract GauloiFillRegistryTest is Test {
 
         // A verifier holding the preimage recomputes the slot value:
         // wrong amount, filler, or block must not match
-        bytes32 stored = registry.getFill(INTENT_ID);
+        bytes32 stored = registry.getFill(INTENT_ID, maker);
         assertEq(stored, keccak256(abi.encode(address(usdc), recipient, FILL_AMOUNT, maker, uint256(12_345))));
         assertTrue(stored != registry.computeFillCommitment(address(usdc), recipient, FILL_AMOUNT - 1, maker, 12_345));
         assertTrue(stored != registry.computeFillCommitment(address(usdc), recipient, FILL_AMOUNT, recipient, 12_345));
@@ -161,7 +175,7 @@ contract GauloiFillRegistryTest is Test {
         registry.fill(intentId, address(usdc), recipient, amount);
 
         assertEq(
-            registry.getFill(intentId),
+            registry.getFill(intentId, maker),
             registry.computeFillCommitment(address(usdc), recipient, amount, maker, block.number)
         );
     }

--- a/packages/common/src/abis/GauloiEscrow.ts
+++ b/packages/common/src/abis/GauloiEscrow.ts
@@ -124,6 +124,25 @@ export const GauloiEscrowAbi = [
   },
   {
     "type": "function",
+    "name": "escrowedBalance",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "executeOrder",
     "inputs": [
       {

--- a/packages/common/src/abis/GauloiFillRegistry.ts
+++ b/packages/common/src/abis/GauloiFillRegistry.ts
@@ -74,6 +74,11 @@ export const GauloiFillRegistryAbi = [
         "name": "intentId",
         "type": "bytes32",
         "internalType": "bytes32"
+      },
+      {
+        "name": "filler",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "outputs": [
@@ -93,6 +98,11 @@ export const GauloiFillRegistryAbi = [
         "name": "intentId",
         "type": "bytes32",
         "internalType": "bytes32"
+      },
+      {
+        "name": "filler",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "outputs": [


### PR DESCRIPTION
Applies fixes for the three findings from the internal security review of the v0.2 stack, each adversarially re-verified.

- **Critical** — `challenge()` requires a corridor resolver; `finalizeExpiredDispute` voids in the maker's favor if a resolver is removed mid-dispute. Closes the force-slash-an-honest-maker vector on unconfigured corridors.
- **High** — `GauloiFillRegistry` keyed by `(intentId, filler)`, eliminating the dust-transfer slot-squatting DoS against makers.
- **Medium** — `rescueTokens` capped to balance above tracked `escrowedBalance` liability; owner can no longer touch funds backing open commitments. `pause()` restored as an owner-callable emergency stop.

203 contract tests + all TS tests passing. Re-review confirmed the `escrowedBalance` invariant holds on every settle/reclaim/resolve/finalize path with no double- or missed-decrement.

Refs #2 #53 #54 #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)