### PR TITLE
feat(disputes): ProofResolver — trustless storage-proof arbiter for provable corridors

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -89,11 +89,19 @@ contract Deploy is Script {
         escrow.setTreasury(treasury);
         escrow.addSupportedToken(usdc);
 
-        // Wire the corridor's resolver (destination chain served from this chain)
+        // Wire the corridor's resolver (destination chain served from this chain).
+        // Council is the default/bootstrap arbiter. A corridor graduates to the
+        // trustless ProofResolver later — that needs an audited IFillProofVerifier
+        // (ZK light client / Axiom / Herodotus) chosen per deployment, so it is
+        // NOT deployed here. To graduate a corridor:
+        //   ProofResolver pr = new ProofResolver(auditedVerifier, address(escrow), owner);
+        //   pr.configureCorridor(destChainId, destFillRegistry, FILLS_SLOT);
+        //   disputes.setResolver(destChainId, address(pr));
+        // FILLS_SLOT is pinned by ProofResolver.t.sol:test_fillSlot_matchesRegistryLayout.
         uint256 destChainId = vm.envOr("DEST_CHAIN_ID", uint256(0));
         if (destChainId != 0) {
             disputes.setResolver(destChainId, address(council));
-            console.log("Resolver wired for corridor:", destChainId);
+            console.log("Council resolver wired for corridor:", destChainId);
         }
 
         vm.stopBroadcast();

--- a/contracts/src/interfaces/IFillProofVerifier.sol
+++ b/contracts/src/interfaces/IFillProofVerifier.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Verifies the value of a single storage slot of a contract on another
+///         chain, against a trusted recent block of that chain. This is the piece
+///         that carries a destination-chain fact to the source chain.
+///
+///         Deliberately behind an interface: the trie/RLP/block-hash cryptography
+///         is the largest and most dangerous surface in the system, so it is NOT
+///         hand-rolled here. A production deployment wires an audited storage-proof
+///         verifier — a ZK light client (Succinct) or a proof service (Axiom,
+///         Herodotus) — whose job is exactly this: given a proof, return the proven
+///         slot value at a trusted block, or revert.
+///
+///         Non-inclusion is a valid, provable outcome: an unset slot proves to
+///         `bytes32(0)`. The verifier MUST revert (not return zero) when the proof
+///         is malformed or the referenced block is not trusted, so a caller can
+///         never confuse "proven empty" with "could not verify".
+///
+///         CRITICAL CONFORMANCE REQUIREMENT — LATEST FINALIZED HEAD ONLY.
+///         The verifier MUST only accept proofs against the latest finalized block
+///         of `chainId` that it tracks, and MUST revert for any historical or
+///         unfinalized block. This is load-bearing, not advisory: FillRegistry
+///         slots are write-once and never cleared, so an empty slot means "not
+///         filled *as of the proven block*", not "never filled". If the verifier
+///         let a caller pick an arbitrary past block, a challenger could prove a
+///         maker's slot empty at a block just before the maker's fill and
+///         false-convict an honest maker (their stake slashed for a fill that
+///         genuinely happened). Proving only at the finalized head makes "empty"
+///         mean "empty now" — and because the slot is monotonic, empty-now implies
+///         never-filled, which is the only safe basis for an Invalid verdict.
+///         A ZK light client (Succinct) tracks the finalized head natively; a
+///         proof service (Axiom/Herodotus) must be constrained to the head block.
+interface IFillProofVerifier {
+    /// @param chainId  The chain whose state is being proven (destination chain)
+    /// @param account  The contract whose storage is being proven (FillRegistry)
+    /// @param slot     The storage slot being proven
+    /// @param proof    Verifier-specific proof (block header, account+storage MPT
+    ///                 proof, or a ZK proof) against the LATEST FINALIZED block of
+    ///                 `chainId` — see the conformance requirement above
+    /// @return value   The proven slot value (bytes32(0) for a proven-empty slot)
+    function verifyStorage(
+        uint256 chainId,
+        address account,
+        bytes32 slot,
+        bytes calldata proof
+    ) external view returns (bytes32 value);
+}

--- a/contracts/src/resolvers/ProofResolver.sol
+++ b/contracts/src/resolvers/ProofResolver.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IResolver} from "../interfaces/IResolver.sol";
+import {IFillProofVerifier} from "../interfaces/IFillProofVerifier.sol";
+import {GauloiEscrow} from "../GauloiEscrow.sol";
+import {DataTypes} from "../types/DataTypes.sol";
+
+/// @notice Trustless terminal arbiter for provable corridors. It resolves a
+///         dispute by proving what the destination FillRegistry actually holds
+///         for the committed maker's slot, then checking that fill against the
+///         order — no council, no vote.
+///
+///         The dangerous cryptography (block-hash trust, MPT/RLP walking) lives
+///         entirely in the injected IFillProofVerifier. This contract owns only
+///         the decision logic:
+///           1. read the committed maker for the intent from escrow (source chain)
+///           2. compute the registry storage slot for (intentId, maker)
+///           3. ask the verifier what that slot holds on the destination chain
+///           4. bind the supplied preimage to the proven commitment
+///           5. decide Valid / Invalid from order satisfaction
+///
+///         A proof of an EMPTY slot (maker never recorded a fill) resolves Invalid.
+///         A proof of a satisfying fill resolves Valid. A proof of a fill that does
+///         not satisfy the order (wrong token/recipient, or amount < minOutput)
+///         resolves Invalid. Anything the verifier cannot prove reverts, so the
+///         dispute stays open for a better proof or the deadline default.
+///
+///         SAFETY DEPENDENCY: the empty-slot → Invalid verdict is only sound
+///         because the verifier proves against the destination's latest finalized
+///         head (see IFillProofVerifier). Registry slots are write-once, so
+///         "empty at head" == "never filled"; a verifier that proved arbitrary
+///         historical blocks would let a challenger false-convict an honest maker.
+///
+///         KNOWN LIMITATION (accepted for v0.2): a maker who marked Filled without
+///         delivering can still back-fill the registry during the dispute window
+///         and prove Valid, harvesting the challenger's bond. The taker is made
+///         whole (the back-fill is a real transfer satisfying the order), so this
+///         is griefing of the challenger, not fund loss. Fully closing it needs a
+///         destination-block ↔ source-time anchor (require the proven fill to
+///         predate the challenge), which is a larger cross-chain-time feature.
+///         Bond economics (forfeited on a losing challenge) bound the incentive.
+contract ProofResolver is IResolver, Ownable {
+    IFillProofVerifier public verifier;
+    GauloiEscrow public immutable escrow;
+
+    struct Corridor {
+        address registry; // FillRegistry address on the destination chain
+        uint256 fillsSlot; // storage slot index of GauloiFillRegistry._fills
+        bool configured;
+    }
+
+    // destination chain id => registry location on that chain
+    mapping(uint256 => Corridor) public corridors;
+
+    event VerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+    event CorridorConfigured(uint256 indexed destinationChainId, address registry, uint256 fillsSlot);
+
+    constructor(address _verifier, address _escrow, address _owner) Ownable(_owner) {
+        require(_verifier != address(0) && _escrow != address(0), "ProofResolver: zero address");
+        verifier = IFillProofVerifier(_verifier);
+        escrow = GauloiEscrow(_escrow);
+    }
+
+    // --- Admin ---
+
+    function setVerifier(address _verifier) external onlyOwner {
+        require(_verifier != address(0), "ProofResolver: zero address");
+        address old = address(verifier);
+        verifier = IFillProofVerifier(_verifier);
+        emit VerifierUpdated(old, _verifier);
+    }
+
+    /// @param fillsSlot storage slot index of `_fills` in GauloiFillRegistry.
+    ///        Pin this against the deployed layout (see ProofResolver test).
+    function configureCorridor(uint256 destinationChainId, address registry, uint256 fillsSlot)
+        external
+        onlyOwner
+    {
+        require(registry != address(0), "ProofResolver: zero registry");
+        corridors[destinationChainId] = Corridor({registry: registry, fillsSlot: fillsSlot, configured: true});
+        emit CorridorConfigured(destinationChainId, registry, fillsSlot);
+    }
+
+    // --- IResolver ---
+
+    /// @param evidence abi.encode(
+    ///          address token, address recipient, uint256 amount, uint256 blockNumber, bytes proof
+    ///        )
+    ///        The first four are the fill-commitment preimage (filler is derived
+    ///        as the committed maker); `proof` is passed to the verifier.
+    function resolve(
+        bytes32 intentId,
+        DataTypes.Order calldata order,
+        bytes calldata evidence
+    ) external view returns (Verdict) {
+        Corridor memory corridor = corridors[order.destinationChainId];
+        require(corridor.configured, "ProofResolver: corridor not configured");
+
+        // The fill must have been recorded by the maker who took the commitment.
+        address maker = escrow.getCommitment(intentId).maker;
+        require(maker != address(0), "ProofResolver: unknown intent");
+
+        bytes32 slot = _fillSlot(intentId, maker, corridor.fillsSlot);
+
+        // What does the destination registry actually hold for this maker's slot?
+        bytes32 provenCommitment =
+            verifier.verifyStorage(order.destinationChainId, corridor.registry, slot, _proof(evidence));
+
+        // Proven empty at the finalized head → never filled (slots are write-once,
+        // so empty-now implies empty-forever). Safe only under the verifier's
+        // latest-finalized-head conformance requirement — see IFillProofVerifier.
+        if (provenCommitment == bytes32(0)) {
+            return Verdict.Invalid;
+        }
+
+        (address token, address recipient, uint256 amount, uint256 blockNumber) = _preimage(evidence);
+
+        // Bind the supplied preimage to the proven commitment — the submitter
+        // cannot lie about the fill's contents, they must match the proven hash.
+        bytes32 expected = keccak256(abi.encode(token, recipient, amount, maker, blockNumber));
+        require(expected == provenCommitment, "ProofResolver: preimage mismatch");
+
+        // A recorded fill that does not satisfy the order is an invalid fill.
+        if (
+            token != order.outputToken ||
+            recipient != order.destinationAddress ||
+            amount < order.minOutputAmount
+        ) {
+            return Verdict.Invalid;
+        }
+
+        return Verdict.Valid;
+    }
+
+    // --- Views / helpers ---
+
+    /// @dev Storage slot of GauloiFillRegistry._fills[keccak256(intentId, filler)].
+    ///      Mirrors the registry's own `_slot(intentId, filler)` keying.
+    function fillStorageSlot(bytes32 intentId, address filler, uint256 fillsSlot)
+        public
+        pure
+        returns (bytes32)
+    {
+        return _fillSlot(intentId, filler, fillsSlot);
+    }
+
+    function _fillSlot(bytes32 intentId, address filler, uint256 fillsSlot) internal pure returns (bytes32) {
+        bytes32 mappingKey = keccak256(abi.encode(intentId, filler));
+        return keccak256(abi.encode(mappingKey, fillsSlot));
+    }
+
+    function _preimage(bytes calldata evidence)
+        internal
+        pure
+        returns (address token, address recipient, uint256 amount, uint256 blockNumber)
+    {
+        (token, recipient, amount, blockNumber,) =
+            abi.decode(evidence, (address, address, uint256, uint256, bytes));
+    }
+
+    function _proof(bytes calldata evidence) internal pure returns (bytes memory proof) {
+        (,,,, proof) = abi.decode(evidence, (address, address, uint256, uint256, bytes));
+    }
+}

--- a/contracts/test/helpers/MockFillProofVerifier.sol
+++ b/contracts/test/helpers/MockFillProofVerifier.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IFillProofVerifier} from "../../src/interfaces/IFillProofVerifier.sol";
+
+/// @dev Test double for the storage-proof verifier. Instead of walking a trie it
+///      returns pre-seeded slot values keyed by (chainId, account, slot), and
+///      reverts for anything unseeded — modelling "cannot verify this proof".
+///      The real verifier would derive `value` from `proof` cryptographically.
+///      The seeded value models the slot at the LATEST FINALIZED HEAD, which is the
+///      only block a conformant verifier proves against (see IFillProofVerifier);
+///      `proof` is opaque and ignored here.
+contract MockFillProofVerifier is IFillProofVerifier {
+    mapping(bytes32 => bytes32) internal _values;
+    mapping(bytes32 => bool) internal _known;
+
+    function setSlot(uint256 chainId, address account, bytes32 slot, bytes32 value) external {
+        bytes32 k = keccak256(abi.encode(chainId, account, slot));
+        _values[k] = value;
+        _known[k] = true;
+    }
+
+    function verifyStorage(
+        uint256 chainId,
+        address account,
+        bytes32 slot,
+        bytes calldata /* proof */
+    ) external view returns (bytes32) {
+        bytes32 k = keccak256(abi.encode(chainId, account, slot));
+        require(_known[k], "MockFillProofVerifier: unverifiable proof");
+        return _values[k];
+    }
+}

--- a/contracts/test/unit/ProofResolver.t.sol
+++ b/contracts/test/unit/ProofResolver.t.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BaseTest} from "../helpers/BaseTest.sol";
+import {MockERC20} from "../helpers/MockERC20.sol";
+import {MockFillProofVerifier} from "../helpers/MockFillProofVerifier.sol";
+import {GauloiStaking} from "../../src/GauloiStaking.sol";
+import {GauloiEscrow} from "../../src/GauloiEscrow.sol";
+import {GauloiDisputes} from "../../src/GauloiDisputes.sol";
+import {GauloiFillRegistry} from "../../src/GauloiFillRegistry.sol";
+import {ProofResolver} from "../../src/resolvers/ProofResolver.sol";
+import {IResolver} from "../../src/interfaces/IResolver.sol";
+import {DataTypes} from "../../src/types/DataTypes.sol";
+import {IntentLib} from "../../src/libraries/IntentLib.sol";
+
+contract ProofResolverTest is BaseTest {
+    ProofResolver public resolver;
+    MockFillProofVerifier public verifier;
+    GauloiFillRegistry public registry; // "destination" registry (same VM in tests)
+
+    address public makerAddr = makeAddr("proofMaker");
+    address public recipient = DEST_ADDRESS;
+
+    // Registry _fills storage slot — pinned by test_fillSlot_matchesRegistryLayout
+    uint256 public constant FILLS_SLOT = 0;
+
+    function setUp() public {
+        taker = vm.addr(takerKey);
+
+        usdc = new MockERC20("USD Coin", "USDC", 6);
+        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
+        escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
+        registry = new GauloiFillRegistry();
+        verifier = new MockFillProofVerifier();
+        resolver = new ProofResolver(address(verifier), address(escrow), owner);
+
+        vm.startPrank(owner);
+        staking.setEscrow(address(escrow));
+        escrow.addSupportedToken(address(usdc));
+        resolver.configureCorridor(DEST_CHAIN_ID, address(registry), FILLS_SLOT);
+        vm.stopPrank();
+
+        usdc.mint(makerAddr, 1_000_000e6);
+        usdc.mint(taker, 1_000_000e6);
+
+        vm.startPrank(makerAddr);
+        usdc.approve(address(staking), 50_000e6);
+        staking.stake(50_000e6);
+        usdc.approve(address(registry), type(uint256).max);
+        vm.stopPrank();
+
+        vm.prank(taker);
+        usdc.approve(address(escrow), type(uint256).max);
+    }
+
+    // Commit + fill an intent; returns intentId and order
+    function _committedIntent(uint256 amount, uint256 minOut)
+        internal
+        returns (bytes32 intentId, DataTypes.Order memory order)
+    {
+        order = _makeOrder(amount, minOut);
+        bytes memory sig = _signOrder(takerKey, order);
+        vm.prank(makerAddr);
+        intentId = escrow.executeOrder(order, sig);
+        vm.prank(makerAddr);
+        escrow.submitFill(order, keccak256("dest"));
+    }
+
+    // Encode ProofResolver evidence (preimage + opaque proof)
+    function _evidence(address token, address recip, uint256 amount, uint256 blockNumber)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(token, recip, amount, blockNumber, hex"");
+    }
+
+    // Seed the verifier so the maker's slot proves to `commitment`
+    function _seed(bytes32 intentId, bytes32 commitment) internal {
+        bytes32 slot = resolver.fillStorageSlot(intentId, makerAddr, FILLS_SLOT);
+        verifier.setSlot(DEST_CHAIN_ID, address(registry), slot, commitment);
+    }
+
+    // =====================================================================
+    // Storage-layout pin: the resolver's slot math MUST match the registry.
+    // If GauloiFillRegistry's storage layout ever changes, this fails loudly.
+    // =====================================================================
+
+    function test_fillSlot_matchesRegistryLayout() public {
+        bytes32 intentId = keccak256("layout-probe");
+        vm.roll(777);
+
+        // Record a real fill in the registry
+        vm.prank(makerAddr);
+        registry.fill(intentId, address(usdc), recipient, 1_000e6);
+
+        bytes32 expected = registry.getFill(intentId, makerAddr);
+        assertTrue(expected != bytes32(0));
+
+        // Read the raw slot the resolver computes and confirm it holds that value
+        bytes32 slot = resolver.fillStorageSlot(intentId, makerAddr, FILLS_SLOT);
+        bytes32 raw = vm.load(address(registry), slot);
+        assertEq(raw, expected, "resolver slot math diverged from registry layout");
+    }
+
+    // =====================================================================
+    // resolve() verdicts
+    // =====================================================================
+
+    function test_resolve_validFill_returnsValid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        // Maker recorded a satisfying fill at dest block 500
+        uint256 blk = 500;
+        bytes32 commitment = registry.computeFillCommitment(address(usdc), recipient, 9_990e6, makerAddr, blk);
+        _seed(intentId, commitment);
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(address(usdc), recipient, 9_990e6, blk));
+        assertTrue(v == IResolver.Verdict.Valid);
+    }
+
+    function test_resolve_emptySlot_returnsInvalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        // Proven empty — maker never recorded a fill
+        _seed(intentId, bytes32(0));
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(address(usdc), recipient, 9_990e6, 500));
+        assertTrue(v == IResolver.Verdict.Invalid);
+    }
+
+    function test_resolve_underpaidFill_returnsInvalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        // Maker recorded a fill for LESS than minOutput
+        uint256 blk = 500;
+        uint256 shortAmount = 9_000e6;
+        bytes32 commitment =
+            registry.computeFillCommitment(address(usdc), recipient, shortAmount, makerAddr, blk);
+        _seed(intentId, commitment);
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(address(usdc), recipient, shortAmount, blk));
+        assertTrue(v == IResolver.Verdict.Invalid);
+    }
+
+    function test_resolve_wrongRecipient_returnsInvalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        uint256 blk = 500;
+        address wrongRecipient = makeAddr("attacker");
+        bytes32 commitment =
+            registry.computeFillCommitment(address(usdc), wrongRecipient, 9_990e6, makerAddr, blk);
+        _seed(intentId, commitment);
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(address(usdc), wrongRecipient, 9_990e6, blk));
+        assertTrue(v == IResolver.Verdict.Invalid);
+    }
+
+    function test_resolve_wrongToken_returnsInvalid() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        uint256 blk = 500;
+        address wrongToken = makeAddr("wrongToken");
+        bytes32 commitment =
+            registry.computeFillCommitment(wrongToken, recipient, 9_990e6, makerAddr, blk);
+        _seed(intentId, commitment);
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(wrongToken, recipient, 9_990e6, blk));
+        assertTrue(v == IResolver.Verdict.Invalid);
+    }
+
+    function test_resolve_lyingPreimage_reverts() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        // Proven slot is a satisfying fill...
+        uint256 blk = 500;
+        bytes32 commitment = registry.computeFillCommitment(address(usdc), recipient, 9_990e6, makerAddr, blk);
+        _seed(intentId, commitment);
+
+        // ...but the submitter provides a preimage that doesn't hash to it
+        vm.expectRevert("ProofResolver: preimage mismatch");
+        resolver.resolve(intentId, order, _evidence(address(usdc), recipient, 1e6, blk));
+    }
+
+    function test_resolve_unverifiableProof_reverts() public {
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+        // Nothing seeded — verifier cannot prove the slot
+        vm.expectRevert("MockFillProofVerifier: unverifiable proof");
+        resolver.resolve(intentId, order, _evidence(address(usdc), recipient, 9_990e6, 500));
+    }
+
+    function test_resolve_unconfiguredCorridor_reverts() public {
+        DataTypes.Order memory order = _makeOrder(10_000e6, 9_990e6);
+        order.destinationChainId = 999_999;
+        // give it a real committed intent id path is unnecessary — corridor check is first
+        vm.expectRevert("ProofResolver: corridor not configured");
+        resolver.resolve(keccak256("x"), order, _evidence(address(usdc), recipient, 9_990e6, 1));
+    }
+
+    function test_resolve_bindsToCommittedMaker_notSubmitter() public {
+        // The proof is looked up at the COMMITTED maker's slot. A fill recorded by
+        // some other address (its own slot) cannot satisfy the dispute.
+        (bytes32 intentId, DataTypes.Order memory order) = _committedIntent(10_000e6, 9_990e6);
+
+        // Seed the committed maker's slot as empty; a different address's slot is
+        // irrelevant because the resolver only ever queries makerAddr's slot.
+        _seed(intentId, bytes32(0));
+
+        IResolver.Verdict v =
+            resolver.resolve(intentId, order, _evidence(address(usdc), recipient, 9_990e6, 500));
+        assertTrue(v == IResolver.Verdict.Invalid);
+    }
+
+    // =====================================================================
+    // Admin
+    // =====================================================================
+
+    function test_setVerifier() public {
+        MockFillProofVerifier v2 = new MockFillProofVerifier();
+        vm.prank(owner);
+        resolver.setVerifier(address(v2));
+        assertEq(address(resolver.verifier()), address(v2));
+
+        vm.prank(owner);
+        vm.expectRevert("ProofResolver: zero address");
+        resolver.setVerifier(address(0));
+
+        vm.prank(makerAddr);
+        vm.expectRevert();
+        resolver.setVerifier(address(v2));
+    }
+
+    function test_configureCorridor_onlyOwner() public {
+        vm.prank(makerAddr);
+        vm.expectRevert();
+        resolver.configureCorridor(1, address(registry), 0);
+    }
+}
+
+/// @dev End-to-end: a dispute resolved trustlessly through the ProofResolver
+///      wired into GauloiDisputes — proving the maker's fill valid releases escrow.
+contract ProofResolverIntegrationTest is BaseTest {
+    GauloiDisputes public disputes;
+    ProofResolver public resolver;
+    MockFillProofVerifier public verifier;
+    GauloiFillRegistry public registry;
+
+    address public makerAddr = makeAddr("e2eProofMaker");
+    address public challengerAddr = makeAddr("e2eProofChallenger");
+    address public treasury = makeAddr("e2eProofTreasury");
+
+    function setUp() public {
+        taker = vm.addr(takerKey);
+
+        usdc = new MockERC20("USD Coin", "USDC", 6);
+        staking = new GauloiStaking(address(usdc), MIN_STAKE, COOLDOWN, 1 hours, owner);
+        escrow = new GauloiEscrow(address(staking), SETTLEMENT_WINDOW, COMMITMENT_TIMEOUT, owner);
+        disputes = new GauloiDisputes(
+            address(staking), address(escrow), address(usdc),
+            24 hours, 200, 250e6, treasury, owner
+        );
+        registry = new GauloiFillRegistry();
+        verifier = new MockFillProofVerifier();
+        resolver = new ProofResolver(address(verifier), address(escrow), owner);
+
+        vm.startPrank(owner);
+        staking.setEscrow(address(escrow));
+        staking.setDisputes(address(disputes));
+        escrow.setDisputes(address(disputes));
+        escrow.addSupportedToken(address(usdc));
+        disputes.setResolver(DEST_CHAIN_ID, address(resolver));
+        resolver.configureCorridor(DEST_CHAIN_ID, address(registry), 0);
+        vm.stopPrank();
+
+        usdc.mint(makerAddr, 1_000_000e6);
+        usdc.mint(challengerAddr, 1_000_000e6);
+        usdc.mint(taker, 1_000_000e6);
+
+        vm.startPrank(makerAddr);
+        usdc.approve(address(staking), 50_000e6);
+        staking.stake(50_000e6);
+        vm.stopPrank();
+
+        vm.prank(taker);
+        usdc.approve(address(escrow), type(uint256).max);
+        vm.prank(challengerAddr);
+        usdc.approve(address(disputes), type(uint256).max);
+    }
+
+    function test_disputeResolvedByProof_validFill() public {
+        DataTypes.Order memory order = _makeOrder(10_000e6, 9_990e6);
+        bytes memory sig = _signOrder(takerKey, order);
+        vm.prank(makerAddr);
+        bytes32 intentId = escrow.executeOrder(order, sig);
+        vm.prank(makerAddr);
+        escrow.submitFill(order, keccak256("dest"));
+
+        // Challenge
+        vm.prank(challengerAddr);
+        disputes.challenge(order);
+        uint256 bond = disputes.calculateDisputeBond(10_000e6);
+
+        // Seed a proof that the maker's registry slot holds a satisfying fill
+        uint256 blk = 500;
+        bytes32 commitment =
+            registry.computeFillCommitment(address(usdc), DEST_ADDRESS, 9_990e6, makerAddr, blk);
+        bytes32 slot = resolver.fillStorageSlot(intentId, makerAddr, 0);
+        verifier.setSlot(DEST_CHAIN_ID, address(registry), slot, commitment);
+
+        bytes memory evidence = abi.encode(address(usdc), DEST_ADDRESS, uint256(9_990e6), blk, hex"");
+
+        uint256 makerBefore = usdc.balanceOf(makerAddr);
+        disputes.resolve(intentId, evidence);
+
+        // Fill proven valid: maker gets escrow + half the challenger's bond
+        assertEq(usdc.balanceOf(makerAddr) - makerBefore, 10_000e6 + bond / 2);
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Settled);
+        assertTrue(disputes.getDispute(intentId).fillDeemedValid);
+    }
+
+    function test_disputeResolvedByProof_missingFill_slashesMaker() public {
+        DataTypes.Order memory order = _makeOrder(20_000e6, 19_950e6);
+        bytes memory sig = _signOrder(takerKey, order);
+        vm.prank(makerAddr);
+        bytes32 intentId = escrow.executeOrder(order, sig);
+        vm.prank(makerAddr);
+        escrow.submitFill(order, keccak256("fake"));
+
+        vm.prank(challengerAddr);
+        disputes.challenge(order);
+
+        // Prove the maker's slot is EMPTY — no fill was recorded
+        bytes32 slot = resolver.fillStorageSlot(intentId, makerAddr, 0);
+        verifier.setSlot(DEST_CHAIN_ID, address(registry), slot, bytes32(0));
+
+        bytes memory evidence = abi.encode(address(usdc), DEST_ADDRESS, uint256(19_950e6), uint256(1), hex"");
+
+        uint256 takerBefore = usdc.balanceOf(taker);
+        disputes.resolve(intentId, evidence);
+
+        // Fill proven invalid: taker refunded, maker slashed
+        assertEq(usdc.balanceOf(taker) - takerBefore, 20_000e6);
+        assertEq(staking.getStake(makerAddr), 50_000e6 - 40_650e6); // 20k * (2 + 650/20000)
+        assertTrue(escrow.getCommitment(intentId).state == DataTypes.IntentState.Expired);
+        assertFalse(disputes.getDispute(intentId).fillDeemedValid);
+    }
+}

--- a/packages/common/scripts/generate-abis.sh
+++ b/packages/common/scripts/generate-abis.sh
@@ -39,6 +39,7 @@ extract_abi "GauloiEscrow"
 extract_abi "GauloiDisputes"
 extract_abi "GauloiFillRegistry"
 extract_abi "CouncilResolver"
+extract_abi "ProofResolver"
 
 # Generate barrel export
 cat > "$ABI_DIR/index.ts" << 'EOF'
@@ -47,6 +48,7 @@ export { GauloiEscrowAbi } from "./GauloiEscrow.js";
 export { GauloiDisputesAbi } from "./GauloiDisputes.js";
 export { GauloiFillRegistryAbi } from "./GauloiFillRegistry.js";
 export { CouncilResolverAbi } from "./CouncilResolver.js";
+export { ProofResolverAbi } from "./ProofResolver.js";
 EOF
 
 echo "ABI generation complete"

--- a/packages/common/src/abis/ProofResolver.ts
+++ b/packages/common/src/abis/ProofResolver.ts
@@ -1,0 +1,337 @@
+export const ProofResolverAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_verifier",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_escrow",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "configureCorridor",
+    "inputs": [
+      {
+        "name": "destinationChainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "registry",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "fillsSlot",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "corridors",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "registry",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "fillsSlot",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "configured",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "escrow",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract GauloiEscrow"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "fillStorageSlot",
+    "inputs": [
+      {
+        "name": "intentId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "filler",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "fillsSlot",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "intentId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "order",
+        "type": "tuple",
+        "internalType": "struct DataTypes.Order",
+        "components": [
+          {
+            "name": "taker",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "inputToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "inputAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "outputToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "minOutputAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "destinationChainId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "destinationAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "expiry",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "nonce",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "evidence",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum IResolver.Verdict"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setVerifier",
+    "inputs": [
+      {
+        "name": "_verifier",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "verifier",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IFillProofVerifier"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "CorridorConfigured",
+    "inputs": [
+      {
+        "name": "destinationChainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "registry",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "fillsSlot",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VerifierUpdated",
+    "inputs": [
+      {
+        "name": "oldVerifier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newVerifier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+] as const;

--- a/packages/common/src/abis/index.ts
+++ b/packages/common/src/abis/index.ts
@@ -3,3 +3,4 @@ export { GauloiEscrowAbi } from "./GauloiEscrow.js";
 export { GauloiDisputesAbi } from "./GauloiDisputes.js";
 export { GauloiFillRegistryAbi } from "./GauloiFillRegistry.js";
 export { CouncilResolverAbi } from "./CouncilResolver.js";
+export { ProofResolverAbi } from "./ProofResolver.js";


### PR DESCRIPTION
Completes the v0.2 resolver set (#56), the last contract piece of the redesign.

- **ProofResolver** resolves a dispute from what the destination FillRegistry provably holds for the committed maker's `(intentId, filler)` slot. Valid fill → maker paid; empty/unsatisfying → maker slashed + taker refunded. Submitter preimage is bound to the proven commitment, so neither party can lie about fill contents.
- **IFillProofVerifier** keeps the block-hash/MPT cryptography injected and audited-separately (ZK light client / Axiom / Herodotus), with a load-bearing conformance requirement: prove only the latest finalized head.
- 14 tests including a `vm.load` layout-pin and two end-to-end proof-resolved disputes through GauloiDisputes.

**Adversarial review** caught and fixed a HIGH (submitter-chosen proof block → false-conviction of an honest maker), closed via the finalized-head requirement. The back-fill-during-window bond-griefing residual is documented (taker still made whole; full fix needs dest-block↔source-time anchoring).

Verifier is deployment-specific, so ProofResolver isn't deployed by default — council remains the bootstrap arbiter and a corridor graduates with one `setResolver`. 217 contract tests + all TS tests passing.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)