### PR TITLE
feat(maker): unit-economics model — minimum viable spread per corridor

### DIFF
--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -1,6 +1,22 @@
 export { MakerBot, type BotConfig } from "./bot.js";
 export { AllowlistScreener, type ComplianceScreener, type ScreenResult } from "./compliance/screener.js";
 export { Quoter, type QuoterConfig } from "./pricing/quoter.js";
+export {
+  computeEconomics,
+  minCompetitiveSizeUsd,
+  spreadFrontier,
+  capitalBps,
+  gasCostUsd,
+  sourceGasUnits,
+  GAS_UNITS,
+  ETH_MAINNET,
+  ARBITRUM,
+  BASE,
+  type ChainGasProfile,
+  type CorridorProfile,
+  type MakerCostParams,
+  type Economics,
+} from "./pricing/unit-economics.js";
 export { Filler } from "./chain/filler.js";
 export { Settler } from "./chain/settler.js";
 export { ChainWatcher } from "./chain/watcher.js";

--- a/packages/maker/src/pricing/unit-economics.test.ts
+++ b/packages/maker/src/pricing/unit-economics.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEconomics,
+  minCompetitiveSizeUsd,
+  capitalBps,
+  spreadFrontier,
+  sourceGasUnits,
+  gasCostUsd,
+  GAS_UNITS,
+  ETH_MAINNET,
+  ARBITRUM,
+  type CorridorProfile,
+  type MakerCostParams,
+} from "./unit-economics.js";
+
+const params: MakerCostParams = {
+  costOfCapitalApr: 0.1, // 10%/yr
+  riskBps: 1,
+  marginBps: 1,
+};
+
+// Ethereum L1 source → Arbitrum dest, 30-min window
+const ethToArb: CorridorProfile = {
+  source: ETH_MAINNET(15, 3_000),
+  dest: ARBITRUM(0.01, 3_000),
+  settlementWindowSec: 30 * 60,
+};
+
+// Arbitrum source → Base dest, 2-min window (both L2)
+const l2ToL2: CorridorProfile = {
+  source: ARBITRUM(0.01, 3_000),
+  dest: ARBITRUM(0.02, 3_000),
+  settlementWindowSec: 2 * 60,
+};
+
+describe("gas cost", () => {
+  it("source gas = execute + submit + settle (batched by default)", () => {
+    expect(sourceGasUnits(true)).toBe(
+      GAS_UNITS.executeOrder + GAS_UNITS.submitFill + GAS_UNITS.settleBatched,
+    );
+    expect(sourceGasUnits(false)).toBe(
+      GAS_UNITS.executeOrder + GAS_UNITS.submitFill + GAS_UNITS.settleStandalone,
+    );
+  });
+
+  it("converts gas units to USD via gwei × ETH price", () => {
+    // 292k gas × 15 gwei × 1e-9 ETH/gwei × $3000 = $13.14
+    const usd = gasCostUsd(292_000, ETH_MAINNET(15, 3_000));
+    expect(usd).toBeCloseTo(292_000 * 15e-9 * 3_000, 6);
+    expect(usd).toBeCloseTo(13.14, 2);
+  });
+});
+
+describe("capital cost", () => {
+  it("is a flat bps independent of trade size (rate × time)", () => {
+    // 10%/yr for 30 min = 0.10 * (1800/31536000) * 1e4 bps
+    const bps = capitalBps(ethToArb, params);
+    expect(bps).toBeCloseTo(0.1 * (1800 / 31_536_000) * 10_000, 9);
+    expect(bps).toBeCloseTo(0.057, 3); // ~0.057 bps — tiny for a 30-min window
+  });
+
+  it("shrinks with a shorter window — the per-corridor-window lever", () => {
+    const short = capitalBps({ ...ethToArb, settlementWindowSec: 120 }, params);
+    const long = capitalBps({ ...ethToArb, settlementWindowSec: 1800 }, params);
+    expect(short).toBeLessThan(long);
+    expect(long / short).toBeCloseTo(15, 1); // 1800/120 = 15×
+  });
+});
+
+describe("computeEconomics", () => {
+  it("gas dominates at small size, vanishes at large size", () => {
+    const small = computeEconomics(ethToArb, params, 1_000);
+    const large = computeEconomics(ethToArb, params, 1_000_000);
+
+    // Same absolute gas cost, wildly different bps
+    expect(small.gasCostUsd).toBeCloseTo(large.gasCostUsd, 6);
+    expect(small.gasBps).toBeGreaterThan(100); // >100 bps on a $1k L1-source trade
+    expect(large.gasBps).toBeLessThan(1); // <1 bp on a $1M trade
+
+    // Breakeven asymptotes toward the floor: the entire gap IS the gas tail,
+    // which keeps shrinking with size (0.13bp at $1M, 0.013bp at $10M)
+    expect(large.breakevenBps - large.floorBps).toBeCloseTo(large.gasBps, 9);
+    const huge = computeEconomics(ethToArb, params, 10_000_000);
+    expect(huge.breakevenBps - huge.floorBps).toBeLessThan(0.05);
+  });
+
+  it("floor = capital + risk, and breakeven >= floor always", () => {
+    const e = computeEconomics(ethToArb, params, 500_000);
+    expect(e.floorBps).toBeCloseTo(e.capitalBps + e.riskBps, 9);
+    expect(e.breakevenBps).toBeGreaterThanOrEqual(e.floorBps);
+    expect(e.quoteBps).toBeCloseTo(e.breakevenBps + params.marginBps, 9);
+  });
+
+  it("L2-source corridor is competitive at far smaller sizes than L1-source", () => {
+    const l1 = computeEconomics(ethToArb, params, 5_000);
+    const l2 = computeEconomics(l2ToL2, params, 5_000);
+    // Same $5k trade: L1 source gas is ~100× the L2 source gas cost
+    expect(l1.gasBps).toBeGreaterThan(l2.gasBps * 50);
+    expect(l2.quoteBps).toBeLessThan(3); // sub-3bp quote viable on a $5k L2 trade
+  });
+});
+
+describe("minCompetitiveSizeUsd", () => {
+  it("finds the size where we can beat a competitor's spread", () => {
+    // Against a 5bp competitor on the L1-source corridor
+    const minSize = minCompetitiveSizeUsd(ethToArb, params, 5);
+    expect(minSize).toBeGreaterThan(10_000);
+    expect(minSize).toBeLessThan(100_000);
+
+    // Just above that size we clear; just below we don't
+    const above = computeEconomics(ethToArb, params, minSize * 1.01);
+    const below = computeEconomics(ethToArb, params, minSize * 0.99);
+    expect(above.quoteBps).toBeLessThanOrEqual(5);
+    expect(below.quoteBps).toBeGreaterThan(5);
+  });
+
+  it("returns Infinity when the floor alone exceeds the competitor", () => {
+    const heavyRisk: MakerCostParams = { ...params, riskBps: 10 };
+    // Competitor at 3bp, but our risk floor is already 10bp → never competitive
+    expect(minCompetitiveSizeUsd(ethToArb, heavyRisk, 3)).toBe(Infinity);
+  });
+
+  it("L2 source collapses the min competitive size", () => {
+    const l1Min = minCompetitiveSizeUsd(ethToArb, params, 5);
+    const l2Min = minCompetitiveSizeUsd(l2ToL2, params, 5);
+    expect(l2Min).toBeLessThan(l1Min / 50);
+  });
+});
+
+describe("spreadFrontier", () => {
+  it("returns economics per size, monotonically decreasing breakeven", () => {
+    const sizes = [1_000, 10_000, 100_000, 1_000_000];
+    const frontier = spreadFrontier(ethToArb, params, sizes);
+    expect(frontier).toHaveLength(4);
+    for (let i = 1; i < frontier.length; i++) {
+      expect(frontier[i].breakevenBps).toBeLessThan(frontier[i - 1].breakevenBps);
+    }
+  });
+});

--- a/packages/maker/src/pricing/unit-economics.ts
+++ b/packages/maker/src/pricing/unit-economics.ts
@@ -1,0 +1,166 @@
+/**
+ * Maker unit economics — the minimum viable spread for a corridor + trade size.
+ *
+ * A maker's spread must recover three costs:
+ *   1. gas       — FIXED per trade, so its bps cost falls as trade size grows
+ *   2. capital   — cost of fronting destination liquidity for the settlement
+ *                  window; a flat bps (rate × time), independent of size
+ *   3. risk      — counterparty/compliance + chain-pair finality, a flat bps
+ *
+ * The only size-dependent term is gas, so the min-spread curve is a hyperbola
+ * in trade size that asymptotes to (capitalBps + riskBps) as size → ∞. That
+ * asymptote is the corridor's structural floor; the gas tail is what makes
+ * small trades uncompetitive.
+ *
+ * Gas units are the measured v0.2 medians (forge --gas-report). See README.
+ */
+
+export const SECONDS_PER_YEAR = 31_536_000;
+
+/** Measured per-function gas (median, isolated calls) */
+export const GAS_UNITS = {
+  executeOrder: 200_000, // source
+  submitFill: 67_000, // source
+  settleStandalone: 62_000, // source
+  settleBatched: 25_000, // source, amortised in a same-maker batch
+  fill: 88_000, // destination (FillRegistry)
+} as const;
+
+export interface ChainGasProfile {
+  name: string;
+  gasPriceGwei: number; // typical gas price
+  nativePriceUsd: number; // USD price of the gas token (ETH)
+}
+
+export interface CorridorProfile {
+  source: ChainGasProfile;
+  dest: ChainGasProfile;
+  settlementWindowSec: number; // dispute/settlement window on this corridor
+  batchedSettlement?: boolean; // maker settles in same-maker batches (default true)
+  /**
+   * Seconds the maker's capital is locked before it can be recycled. Defaults
+   * to the settlement window (repayment latency). Set higher to include
+   * cross-chain rebalancing time if the maker can't immediately reuse funds.
+   */
+  capitalLockSec?: number;
+}
+
+export interface MakerCostParams {
+  costOfCapitalApr: number; // e.g. 0.10 for 10%/yr
+  riskBps: number; // counterparty/compliance + finality premium, in bps
+  marginBps: number; // target profit on top of breakeven
+}
+
+export interface Economics {
+  tradeSizeUsd: number;
+  gasCostUsd: number;
+  capitalCostUsd: number;
+  // bps breakdown
+  gasBps: number;
+  capitalBps: number;
+  riskBps: number;
+  breakevenBps: number; // gas + capital + risk (below this, the maker loses money)
+  quoteBps: number; // breakeven + margin (what the maker should quote)
+  floorBps: number; // capital + risk — the asymptote as size → ∞
+}
+
+/** Total source-chain gas per trade for the maker (execute + submit + settle) */
+export function sourceGasUnits(batched: boolean): number {
+  const settle = batched ? GAS_UNITS.settleBatched : GAS_UNITS.settleStandalone;
+  return GAS_UNITS.executeOrder + GAS_UNITS.submitFill + settle;
+}
+
+/** USD gas cost for `gasUnits` on a chain */
+export function gasCostUsd(gasUnits: number, chain: ChainGasProfile): number {
+  const ethPerGas = gasUnits * chain.gasPriceGwei * 1e-9; // gwei → ETH
+  return ethPerGas * chain.nativePriceUsd;
+}
+
+/** Flat bps cost of capital for the lock duration (independent of trade size) */
+export function capitalBps(corridor: CorridorProfile, params: MakerCostParams): number {
+  const lockSec = corridor.capitalLockSec ?? corridor.settlementWindowSec;
+  return params.costOfCapitalApr * (lockSec / SECONDS_PER_YEAR) * 10_000;
+}
+
+/** Full economics for one corridor + trade size */
+export function computeEconomics(
+  corridor: CorridorProfile,
+  params: MakerCostParams,
+  tradeSizeUsd: number,
+): Economics {
+  const batched = corridor.batchedSettlement ?? true;
+
+  const srcGas = gasCostUsd(sourceGasUnits(batched), corridor.source);
+  const dstGas = gasCostUsd(GAS_UNITS.fill, corridor.dest);
+  const totalGasUsd = srcGas + dstGas;
+
+  const capBps = capitalBps(corridor, params);
+  const capitalCostUsd = (capBps / 10_000) * tradeSizeUsd;
+
+  const gasBps = (totalGasUsd / tradeSizeUsd) * 10_000;
+  const floorBps = capBps + params.riskBps;
+  const breakevenBps = gasBps + floorBps;
+
+  return {
+    tradeSizeUsd,
+    gasCostUsd: totalGasUsd,
+    capitalCostUsd,
+    gasBps,
+    capitalBps: capBps,
+    riskBps: params.riskBps,
+    breakevenBps,
+    quoteBps: breakevenBps + params.marginBps,
+    floorBps,
+  };
+}
+
+/**
+ * Smallest trade size (USD) at which the maker can quote at or below a
+ * competitor's spread and still clear breakeven + margin. Returns Infinity if
+ * the corridor's floor alone already exceeds the competitor (never competitive
+ * at any size), or 0 if competitive even as size → 0.
+ */
+export function minCompetitiveSizeUsd(
+  corridor: CorridorProfile,
+  params: MakerCostParams,
+  competitorBps: number,
+): number {
+  const batched = corridor.batchedSettlement ?? true;
+  const totalGasUsd =
+    gasCostUsd(sourceGasUnits(batched), corridor.source) + gasCostUsd(GAS_UNITS.fill, corridor.dest);
+
+  // Need: gasBps(size) + floorBps + marginBps <= competitorBps
+  // gasBps(size) = totalGasUsd / size * 1e4  →  size >= totalGasUsd*1e4 / headroom
+  const headroom = competitorBps - (capitalBps(corridor, params) + params.riskBps) - params.marginBps;
+  if (headroom <= 0) return Infinity; // floor+margin already above competitor
+  return (totalGasUsd * 10_000) / headroom;
+}
+
+/** Sweep trade sizes and return economics at each — the frontier */
+export function spreadFrontier(
+  corridor: CorridorProfile,
+  params: MakerCostParams,
+  sizesUsd: number[],
+): Economics[] {
+  return sizesUsd.map((s) => computeEconomics(corridor, params, s));
+}
+
+// --- Chain presets (edit gas price / ETH to taste) ---
+
+export const ETH_MAINNET = (gasPriceGwei = 15, ethUsd = 3_000): ChainGasProfile => ({
+  name: "Ethereum",
+  gasPriceGwei,
+  nativePriceUsd: ethUsd,
+});
+
+export const ARBITRUM = (gasPriceGwei = 0.01, ethUsd = 3_000): ChainGasProfile => ({
+  name: "Arbitrum",
+  gasPriceGwei,
+  nativePriceUsd: ethUsd,
+});
+
+export const BASE = (gasPriceGwei = 0.02, ethUsd = 3_000): ChainGasProfile => ({
+  name: "Base",
+  gasPriceGwei,
+  nativePriceUsd: ethUsd,
+});

--- a/scripts/spread-frontier.ts
+++ b/scripts/spread-frontier.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * Render the maker min-spread frontier per corridor, so you can see where gas
+ * stops eating the spread before committing liquidity.
+ *
+ *   pnpm tsx scripts/spread-frontier.ts
+ *   ETH_GWEI=30 ETH_USD=3500 COMPETITOR_BPS=5 pnpm tsx scripts/spread-frontier.ts
+ */
+import {
+  computeEconomics,
+  minCompetitiveSizeUsd,
+  ETH_MAINNET,
+  ARBITRUM,
+  BASE,
+  type CorridorProfile,
+  type MakerCostParams,
+} from "../packages/maker/src/pricing/unit-economics.js";
+
+const ethGwei = Number(process.env.ETH_GWEI ?? 15);
+const ethUsd = Number(process.env.ETH_USD ?? 3_000);
+const competitorBps = Number(process.env.COMPETITOR_BPS ?? 5);
+
+const params: MakerCostParams = {
+  costOfCapitalApr: Number(process.env.COC_APR ?? 0.1),
+  riskBps: Number(process.env.RISK_BPS ?? 1),
+  marginBps: Number(process.env.MARGIN_BPS ?? 1),
+};
+
+const SIZES = [1_000, 10_000, 100_000, 1_000_000, 5_000_000];
+
+const corridors: { label: string; corridor: CorridorProfile }[] = [
+  {
+    label: "Ethereum L1 → Arbitrum (30-min window)",
+    corridor: { source: ETH_MAINNET(ethGwei, ethUsd), dest: ARBITRUM(0.01, ethUsd), settlementWindowSec: 1800 },
+  },
+  {
+    label: "Ethereum L1 → Arbitrum (2-min window, provable)",
+    corridor: { source: ETH_MAINNET(ethGwei, ethUsd), dest: ARBITRUM(0.01, ethUsd), settlementWindowSec: 120 },
+  },
+  {
+    label: "Arbitrum → Base (2-min window, both L2)",
+    corridor: { source: ARBITRUM(0.01, ethUsd), dest: BASE(0.02, ethUsd), settlementWindowSec: 120 },
+  },
+];
+
+function fmtUsd(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(0)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}k`;
+  return `$${n.toFixed(0)}`;
+}
+
+function pad(s: string, w: number): string {
+  return s.length >= w ? s : s + " ".repeat(w - s.length);
+}
+function padL(s: string, w: number): string {
+  return s.length >= w ? s : " ".repeat(w - s.length) + s;
+}
+
+console.log(
+  `\nMaker min-spread frontier   |   ETH ${ethGwei} gwei @ $${ethUsd}   |   ` +
+    `cost-of-capital ${(params.costOfCapitalApr * 100).toFixed(0)}%/yr, ` +
+    `risk ${params.riskBps}bp, margin ${params.marginBps}bp   |   competitor ${competitorBps}bp\n`,
+);
+
+for (const { label, corridor } of corridors) {
+  const minSize = minCompetitiveSizeUsd(corridor, params, competitorBps);
+  const minSizeStr = minSize === Infinity ? "never (floor > competitor)" : `${fmtUsd(minSize)}+`;
+  console.log(`── ${label}`);
+  console.log(`   gas/trade: ${fmtGas(corridor)}   ·   beats ${competitorBps}bp competitor above: ${minSizeStr}`);
+  console.log(
+    "   " +
+      pad("size", 8) +
+      padL("gas bp", 10) +
+      padL("capital bp", 12) +
+      padL("risk bp", 9) +
+      padL("breakeven", 11) +
+      padL("quote", 8) +
+      padL("vs comp", 9),
+  );
+  for (const size of SIZES) {
+    const e = computeEconomics(corridor, params, size);
+    const beats = e.quoteBps <= competitorBps ? "win" : "lose";
+    console.log(
+      "   " +
+        pad(fmtUsd(size), 8) +
+        padL(e.gasBps.toFixed(2), 10) +
+        padL(e.capitalBps.toFixed(3), 12) +
+        padL(e.riskBps.toFixed(0), 9) +
+        padL(e.breakevenBps.toFixed(2), 11) +
+        padL(e.quoteBps.toFixed(2), 8) +
+        padL(beats, 9),
+    );
+  }
+  console.log("");
+}
+
+function fmtGas(corridor: CorridorProfile): string {
+  const e = computeEconomics(corridor, params, 1_000_000);
+  return `$${e.gasCostUsd.toFixed(2)}`;
+}


### PR DESCRIPTION
A pricing model + frontier renderer so you can see where gas stops eating the spread before committing liquidity. Quantifies gas (fixed) + capital (flat bps) + risk, and computes the min competitive ticket size per corridor. 11 tests. See scripts/spread-frontier.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)